### PR TITLE
Support showing inline pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,12 @@
 
 This is a WIP, this README represents what I want, not what it is yet. 
 
-It is kind of blocked on https://github.com/facebook/jest/issues/1900 for the moment
-
 ## The Aim
 
 A comprehensive experience when using Jest with a project. 
 
 * Useful Feedback
 * Session based test watching
-
----
 
 ### Feedback
 
@@ -25,4 +21,9 @@ A comprehensive experience when using Jest with a project.
 ### Session based watching
 
 * Opening a project with Jest should start to run the tests by default, you should be able to opt out
+* Should be able to declare what the command to run jest should look like
 * Closing a project, should close the tests
+
+## Keep your eye on
+
+If we need more metadata, then look at - https://github.com/facebook/jest/issues/1900

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-jest",
   "displayName": "vscode-jest",
   "description": "Improve your Jest testing workflow in VS Code.",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "publisher": "Orta",
   "engines": {
     "vscode": "^1.5.0"

--- a/src/decorations.ts
+++ b/src/decorations.ts
@@ -1,0 +1,47 @@
+'use strict';
+
+import * as vscode from 'vscode';
+
+export function unknownItName() {
+    return vscode.window.createTextEditorDecorationType({
+        borderWidth: '1px',
+        borderStyle: 'solid',
+        light: {
+            // this color will be used in light color themes
+            borderColor: 'black'
+        },
+        dark: {
+            // this color will be used in dark color themes
+            borderColor: 'black'
+        },
+        before: {
+            contentText: "F",
+            border: "white",
+            backgroundColor: "black",
+            width: "20"
+        }
+    });
+}
+
+export function failingItName() {
+    return vscode.window.createTextEditorDecorationType({
+        overviewRulerColor: 'red',
+        overviewRulerLane: vscode.OverviewRulerLane.Left,
+        before: {
+            color: "green",
+            contentText: "●",
+        }
+    });
+}
+
+export function passingItName() {
+    return vscode.window.createTextEditorDecorationType({
+        overviewRulerColor: 'green',
+        overviewRulerLane: vscode.OverviewRulerLane.Left,
+        before: {
+            color: "green",
+            contentText: "●",
+        }
+    });
+}
+

--- a/src/jest_runner.ts
+++ b/src/jest_runner.ts
@@ -28,9 +28,9 @@ export class JestRunner extends EventEmitter {
         this.debugprocess = childProcess.spawn(runtimeExecutable, runtimeArgs, {cwd: processCwd, env: processEnv});
 
         this.debugprocess.stdout.on('data', (data: Buffer) => {
-            let stringValue = data.toString()
-            // verify last char too?
-            if (stringValue.charAt(0) == "{") {
+            // Convert to JSON and strip any trailing newlines
+            let stringValue = data.toString().replace(/\n$/, "")
+            if (stringValue.substr(0, 1) === "{" && stringValue.substr(-1, 1) === "}") {
                 this.emit('executableJSON', JSON.parse(stringValue));
             } else {
                 this.emit('executableOutput', stringValue);

--- a/src/test_file_parser.ts
+++ b/src/test_file_parser.ts
@@ -26,7 +26,7 @@ export class ItBlock {
     }
 }
 
-export default class TestFileParser {
+export class TestFileParser {
 
     itBlocks: ItBlock[]
 

--- a/test/fixtures/metaphysics/partner_show.js
+++ b/test/fixtures/metaphysics/partner_show.js
@@ -1,0 +1,223 @@
+import moment from 'moment';
+
+describe('PartnerShow type', () => {
+  const PartnerShow = schema.__get__('PartnerShow');
+  let total = null;
+  let gravity = null;
+  let showData = null;
+
+  beforeEach(() => {
+    gravity = sinon.stub();
+    total = sinon.stub();
+
+    showData = {
+      id: 'new-museum-1-2015-triennial-surround-audience',
+      start_at: '2015-02-25T12:00:00+00:00',
+      end_at: '2015-05-24T12:00:00+00:00',
+      press_release: '**foo** *bar*',
+      displayable: true,
+      partner: {
+        id: 'new-museum',
+      },
+      display_on_partner_profile: true,
+      eligible_artworks_count: 8,
+    };
+    gravity.returns(Promise.resolve(showData));
+
+    PartnerShow.__Rewire__('gravity', gravity);
+    PartnerShow.__Rewire__('total', total);
+  });
+
+  afterEach(() => {
+    PartnerShow.__ResetDependency__('gravity');
+    PartnerShow.__ResetDependency__('total');
+  });
+
+  it('includes a formattable start and end date', () => {
+    const query = `
+      {
+        partner_show(id: "new-museum-1-2015-triennial-surround-audience") {
+          id
+          start_at(format: "dddd, MMMM Do YYYY, h:mm:ss a")
+          end_at(format: "YYYY")
+        }
+      }
+    `;
+
+    return runQuery(query)
+      .then(data => {
+        expect(PartnerShow.__get__('gravity').args[0][0])
+          .to.equal('show/new-museum-1-2015-triennial-surround-audience');
+
+        expect(data).to.eql({
+          partner_show: {
+            id: 'new-museum-1-2015-triennial-surround-audience',
+            start_at: 'Wednesday, February 25th 2015, 12:00:00 pm',
+            end_at: '2015',
+          },
+        });
+      });
+  });
+
+  it('includes a formatted exhibition period', () => {
+    const query = `
+      {
+        partner_show(id: "new-museum-1-2015-triennial-surround-audience") {
+          exhibition_period
+        }
+      }
+    `;
+
+    return runQuery(query)
+      .then(data => {
+        expect(data).to.eql({
+          partner_show: {
+            exhibition_period: 'Feb 25 – May 24, 2015',
+          },
+        });
+      });
+  });
+
+  it('includes an update on upcoming status changes', () => {
+    showData.end_at = moment().add(1, 'd');
+
+    const query = `
+      {
+        partner_show(id: "new-museum-1-2015-triennial-surround-audience") {
+          status_update
+        }
+      }
+    `;
+
+    return runQuery(query)
+      .then(data => {
+        expect(data).to.eql({
+          partner_show: {
+            status_update: 'Closing tomorrow',
+          },
+        });
+      });
+  });
+
+  it('includes the html version of markdown', () => {
+    const query = `
+      {
+        partner_show(id: "new-museum-1-2015-triennial-surround-audience") {
+          press_release(format: markdown)
+        }
+      }
+    `;
+
+    return runQuery(query)
+      .then(data => {
+        expect(PartnerShow.__get__('gravity').args[0][0])
+          .to.equal('show/new-museum-1-2015-triennial-surround-audience');
+
+        expect(data).to.eql({
+          partner_show: {
+            press_release: '<p><strong>foo</strong> <em>bar</em></p>\n',
+          },
+        });
+      });
+  });
+
+  it('includes the total number of artworks', () => {
+    total
+      .onCall(0)
+      .returns(Promise.resolve(42));
+
+    const query = `
+      {
+        partner_show(id: "new-museum-1-2015-triennial-surround-audience") {
+          counts {
+            artworks
+          }
+        }
+      }
+    `;
+
+    return runQuery(query)
+      .then(data => {
+        expect(data).to.eql({
+          partner_show: {
+            counts: {
+              artworks: 42,
+            },
+          },
+        });
+      });
+  });
+
+  it('includes the total number of eligible artworks', () => {
+    const query = `
+      {
+        partner_show(id: "new-museum-1-2015-triennial-surround-audience") {
+          counts {
+            eligible_artworks
+          }
+        }
+      }
+    `;
+
+    return runQuery(query)
+      .then(data => {
+        expect(data).to.eql({
+          partner_show: {
+            counts: {
+              eligible_artworks: 8,
+            },
+          },
+        });
+      });
+  });
+
+  it('includes the number of artworks by a specific artist', () => {
+    total
+      .onCall(0)
+      .returns(Promise.resolve(2));
+
+    const query = `
+      {
+        partner_show(id: "new-museum-1-2015-triennial-surround-audience") {
+          counts {
+            artworks(artist_id: "juliana-huxtable")
+          }
+        }
+      }
+    `;
+
+    return runQuery(query)
+      .then(data => {
+        expect(data).to.eql({
+          partner_show: {
+            counts: {
+              artworks: 2,
+            },
+          },
+        });
+      });
+  });
+
+  it('does not return errors when there is no cover image', () => {
+    gravity
+      .onCall(1)
+      .returns(Promise.resolve([]));
+
+    const query = `
+      {
+        partner_show(id: "new-museum-1-2015-triennial-surround-audience") {
+          cover_image {
+            id
+          }
+        }
+      }
+    `;
+
+    return runQuery(query)
+      .then(({ partner_show }) => {
+        expect(partner_show).to.eql({
+          cover_image: null,
+        });
+      });
+  });
+});

--- a/test/test_file_parser.test.ts
+++ b/test/test_file_parser.test.ts
@@ -6,12 +6,12 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import * as myExtension from '../src/extension';
 
-import Parser from '../src/test_file_parser'
+import { TestFileParser } from '../src/test_file_parser'
 
 suite("File Parsing", () => {
 
     test("For the simplest global case", async () => {
-        let parser = new Parser()
+        let parser = new TestFileParser()
         await parser.run(__dirname + "/../../test/fixtures/global_its.js")
         assert.equal(parser.itBlocks.length, 2)
         
@@ -27,7 +27,7 @@ suite("File Parsing", () => {
     });
 
     test("For its inside describes", async () => {
-        let parser = new Parser()
+        let parser = new TestFileParser()
         await parser.run(__dirname + "/../../test/fixtures/nested_its.js")
         assert.equal(parser.itBlocks.length, 3)
         
@@ -48,13 +48,13 @@ suite("File Parsing", () => {
     });
 
     test("For a danger test file (which has flow annotations)", async () => {
-        let parser = new Parser()
+        let parser = new TestFileParser()
         await parser.run(__dirname + "/../../test/fixtures/dangerjs/travis-ci.jstest.js")
         assert.equal(parser.itBlocks.length, 7)
     })
 
     test("For a metaphysics test file", async () => {
-        let parser = new Parser()
+        let parser = new TestFileParser()
         await parser.run(__dirname + "/../../test/fixtures/metaphysics/partner_show.js")
         assert.equal(parser.itBlocks.length, 8)
     })

--- a/test/test_file_parser.test.ts
+++ b/test/test_file_parser.test.ts
@@ -52,4 +52,10 @@ suite("File Parsing", () => {
         await parser.run(__dirname + "/../../test/fixtures/dangerjs/travis-ci.jstest.js")
         assert.equal(parser.itBlocks.length, 7)
     })
+
+    test("For a metaphysics test file", async () => {
+        let parser = new Parser()
+        await parser.run(__dirname + "/../../test/fixtures/metaphysics/partner_show.js")
+        assert.equal(parser.itBlocks.length, 8)
+    })
 });


### PR DESCRIPTION
![screen shot 2016-10-24 at 17 10 57](https://cloud.githubusercontent.com/assets/49038/19653717/787f7a44-9a0d-11e6-9b5d-4b39e58b66b0.png)

The plugin will now highlight all of the it blocks inside your text editor. I think realistically now I'm re-blocked on the Jest PR I talked about in #1. 

I need structured failure data, otherwise this plugin is going to have to parse through these kind of strings:

![screen shot 2016-10-24 at 17 16 34](https://cloud.githubusercontent.com/assets/49038/19653791/b99e847a-9a0d-11e6-887d-b6f552afdbda.png)

This could be fine, but there's only one error per file - so multiple tests could fail, and I think that's something that could change between versions, so better to get some real structure back there.