### PR TITLE
Give an error for older Jest versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.3.2
+
+* Adds an error message if you're not using Jest 17 - orta
+
 ### 1.3.0 - 1.3.1
 
 * Windows support - orta

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Open up VS Code, go search for the extension "Jest"
 
 This project has the expectation that you would run something like `npm run test` which _just_ looks like `jest` in the `package.json`. So, please keep your configuration inside the `package.json` as opposed to using command line arguments.
 
+Also, you will need to use Jest 17+.
+
 ## Future Ideas
 
 * Add a statusbar button when snapshots have failed to re-run tests with update

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -192,7 +192,11 @@ class JestExt  {
 
     // Get the settings from Jest's JSON output
     getSettings() {
-        this.jestSettings.getConfig();
+        this.jestSettings.getConfig(() => {
+            if (this.jestSettings.jestVersionMajor < 17) {
+                vscode.window.showErrorMessage("This extension requires Jest 17+", { title: "Sigh, I'll go update my Jest"});
+            }
+        });
     }
 
     wouldJestRunURI(uri: vscode.Uri): boolean {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -6,7 +6,6 @@ import {platform} from 'os';
  * 
  * @returns {string}
  */
-
 export function pathToJest(): string {
   const jestSettings: any = workspace.getConfiguration("jest");
   const path: string = jestSettings.pathToJest;


### PR DESCRIPTION
version 17 was when my PRs that make this extension possible came in, so that's the new baseline. It will still run, but you get a message

![screen shot 2016-11-29 at 10 20 18](https://cloud.githubusercontent.com/assets/49038/20706175/d9109970-b61d-11e6-9297-de6dc3b8e49e.png)
