### PR TITLE
Make not-ran tests indicator a green circle

### DIFF
--- a/src/decorations.ts
+++ b/src/decorations.ts
@@ -46,13 +46,13 @@ export function notRanItName() {
         overviewRulerLane: vscode.OverviewRulerLane.Left,
         dark: {
             before: {
-                color: "darkgrey",
+                color: "#3BB26B",
                 contentText: "○",
             }    
         },
         light: {
             before: {
-                color: "lightgrey",
+                color: "#2F8F51",
                 contentText: "○",
             }    
         }


### PR DESCRIPTION
Issue #18 

Very simple change: a green circle is more rewarding than a lightgrey one.

I used the same green as the passed case.

Test case:

![image](https://cloud.githubusercontent.com/assets/691940/20724143/5d99e1f2-b66d-11e6-9398-201eb07c408c.png)
