### PR TITLE
normalize path to make the default path to jest work on windows

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,5 +1,6 @@
 import {workspace} from 'vscode';
 import {platform} from 'os';
+import {normalize} from 'path';
 
 /**
  *  Handles getting the jest runner, handling the OS specific work too
@@ -8,7 +9,7 @@ import {platform} from 'os';
  */
 export function pathToJest(): string {
   const jestSettings: any = workspace.getConfiguration("jest");
-  const path: string = jestSettings.pathToJest;
+  const path: string = normalize(jestSettings.pathToJest);
 
   // For windows support, see https://github.com/orta/vscode-jest/issues/10
   if (!path.includes(".cmd") && platform() === "win32") { return path + ".cmd";  }


### PR DESCRIPTION
I believe this should allow the default jestPath to work on Windows without having to override now.