### PR TITLE
Migrate all non-vscode related code into a specific lib folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 1.6.0
+
+* Separation of VS Code specific code from the extension by creating a lib directory, 
+  in prepration for moving to the Jest repo - https://github.com/facebook/jest/issues/2183 - orta
+* Minor improvements for create-react users - orta
+
 ### 1.5.1
 
 * Use green empty circles for tests assumed to be good - gabro

--- a/src/lib/jest_process.ts
+++ b/src/lib/jest_process.ts
@@ -1,0 +1,27 @@
+'use strict';
+
+import {ChildProcess, spawn} from 'child_process';
+import {ProjectWorkspace} from './project_workspace';
+
+/**
+ * Spawns and returns a Jest process with specific args 
+ * 
+ * @param {string[]} args
+ * @returns {ChildProcess}
+ */
+
+export function jestChildProcessWithArgs(workspace: ProjectWorkspace, args: string[]) : ChildProcess {
+        // A command could look like `npm run test`, which we cannot use as a command
+        // as they can only be the first command, so take out the command, and add
+        // any other bits into the args
+        const runtimeExecutable = workspace.pathToJest;
+        const [command, ...initialArgs] = runtimeExecutable.split(" ");
+        const runtimeArgs = [...initialArgs, ...args];
+        
+        // To use our own commands in create-react, we need to tell the command that we're in a CI
+        // environment, or it will always append --watch
+        const env = process.env;
+        env["CI"] = true;
+
+        return spawn(command, runtimeArgs,  {cwd: workspace.rootPath, env: env});
+    }

--- a/src/lib/jest_settings.ts
+++ b/src/lib/jest_settings.ts
@@ -1,10 +1,11 @@
 'use strict';
 
-import * as childProcess from 'child_process';
+import {ChildProcess} from 'child_process';
 import {EventEmitter} from 'events';
-import {workspace} from 'vscode';
-import {pathToJest} from './helpers';
 import {EOL} from 'os';
+import {ProjectWorkspace} from './project_workspace';
+import {jestChildProcessWithArgs} from './jest_process';
+
 // This class represents the the configuration of Jest's process
 // we want to start with the defaults then override whatever they output
 // the interface below can be used to show what we use, as currently the whole
@@ -13,37 +14,33 @@ import {EOL} from 'os';
 // Ideally anything you care about adding should have a default in the constructor
 // see https://facebook.github.io/jest/docs/configuration.html for full deets
 
-// For now, this is all we care about
+// For now, this is all we care about inside the config
 interface JestConfigRepresentation {
   testRegex: string;
 }
 
 export class JestSettings extends EventEmitter {
-    private debugprocess: childProcess.ChildProcess;
+    private debugprocess: ChildProcess;
+    private workspace: ProjectWorkspace;
+    
     settings: JestConfigRepresentation;
     jestVersionMajor: number | null;
-
-    constructor() {
+    
+    constructor(workspace: ProjectWorkspace) {
       super();
-      // Defaults for a project
+      this.workspace = workspace;
+
+      // Defaults for a Jest project
       this.settings = {
         testRegex: "(/__tests__/.*|\\.(test|spec))\\.jsx?$"
       }; 
     }
 
     getConfig(completed: any) {
-        // A command could look like `npm test --` which doesn't work
-        const runtimeExecutable = pathToJest();
-        const [command, ...initialArgs] = runtimeExecutable.split(" ");
-
         // It'll want to run tests, we don't want that, so tell it to run tests
         // in a non-existant folder.
         const folderThatDoesntExist = "aaskdjfbsjdhbfdhjsfjh";
-        var runtimeArgs = [...initialArgs, '--debug', folderThatDoesntExist];
-
-        const env = process.env;
-        env["CI"] = true;
-        this.debugprocess = childProcess.spawn(command, runtimeArgs, {cwd: workspace.rootPath, env: env});
+        this.debugprocess = jestChildProcessWithArgs(this.workspace, ["--debug", folderThatDoesntExist]);
 
         this.debugprocess.stdout.on('data', (data: Buffer) => {
             const string = data.toString();

--- a/src/lib/project_workspace.ts
+++ b/src/lib/project_workspace.ts
@@ -1,0 +1,31 @@
+'use strict';
+
+/**
+ * Represents the project that the extension is running on and it's state
+ */
+export class ProjectWorkspace {
+  /**
+   * The path to the root of the project's workspace
+   * 
+   * @type {string}
+   */
+  rootPath: string;
+
+  /**
+   * The path to Jest, this is normally a file path like
+   * `node_modules/.bin/jest` but you should not make the assumption that 
+   * it is always a direct file path, as in a create-react app it would look
+   * like `npm test --`. 
+   * 
+   * This means when launching a process, you will need to split on the first
+   * space, and then move any other args into the args of the process.
+   * 
+   * @type {string}
+   */
+  pathToJest: string;
+
+  constructor(rootPath: string, pathToJest: string) {
+    this.rootPath = rootPath;
+    this.pathToJest = pathToJest;
+  }
+}

--- a/src/lib/test_file_parser.ts
+++ b/src/lib/test_file_parser.ts
@@ -1,8 +1,7 @@
 'use strict';
 
-import fs = require('fs');
+import {readFile} from 'fs';
 import * as babylon from 'babylon';
-import * as vscode from 'vscode';
 
 interface Location {
     line: number;
@@ -35,12 +34,7 @@ export class ItBlock {
 
 export class TestFileParser {
     itBlocks: ItBlock[];
-    private channel: vscode.OutputChannel;
     expects: Expect[];
-
-    public constructor(outputChannel: vscode.OutputChannel | null) {
-        this.channel = outputChannel;
-    }
 
     async run(file: string): Promise<any> {
         this.itBlocks = [];
@@ -51,8 +45,7 @@ export class TestFileParser {
             this.findItBlocksInBody(data["program"], file);
             return data;
         } catch (error) {
-            this.channel.appendLine(`Could not parse ${file} for it/test statements.`);
-            return {};
+            throw error;
         }
     }
 
@@ -155,7 +148,7 @@ export class TestFileParser {
 
     generateAST(file: string): Promise<babylon.Node> {
         return new Promise((resolve, reject) =>{
-            fs.readFile(file, "utf8", (err, data) => {
+            readFile(file, "utf8", (err, data) => {
                 if (err) { return reject(err.message); }
 
                 try {

--- a/src/lib/test_reconciler.ts
+++ b/src/lib/test_reconciler.ts
@@ -1,15 +1,25 @@
 'use strict';
 
-import * as vscode from 'vscode';
 import { basename } from 'path';
-import { JestTotalResults, JestAssertionResults } from './extension';
+import { JestTotalResults, JestAssertionResults } from './types';
 
+/**
+ *  Did the thing pass, fail or was it not run?
+ */
 export enum TestReconcilationState {
+  /** This could be that the file has not changed, so the watched didn't hit it */
   Unknown = 1,
+  /** Definitely failed */
   KnownFail = 2,
+  /** Definitely passed */
   KnownSuccess = 3
 }
 
+/**
+ * The Jest Extension's version of a status for
+ * whether the file passed or not
+ * 
+ */
 export interface TestFileAssertionStatus {
   file: string;
   message: string;
@@ -17,6 +27,11 @@ export interface TestFileAssertionStatus {
   assertions: TestAssertionStatus[];
 }
 
+/**
+ * The Jest Extension's version of a status for
+ * individual assertion fails
+ * 
+ */
 export interface TestAssertionStatus {
   title: string;
   status: TestReconcilationState;
@@ -25,6 +40,14 @@ export interface TestAssertionStatus {
   terseMessage: string;
   line: number | null;
 }
+
+/**
+ *  You have a Jest test runner watching for changes, and you have
+ *  an extension that wants to know where to show errors after file parsing.
+ * 
+ *  This class represents the state between runs, keeping track of passes/fails
+ *  at a file level, generating useful error messages and providing a nice API. 
+ */
 
 export class TestReconciler {
   private fileStatuses: any;
@@ -109,14 +132,14 @@ export class TestReconciler {
     }
   }
 
-  stateForTestFile(file:vscode.Uri): TestReconcilationState {
-    const results: TestFileAssertionStatus = this.fileStatuses[file.fsPath];
+  stateForTestFile(file:string): TestReconcilationState {
+    const results: TestFileAssertionStatus = this.fileStatuses[file];
     if (!results) { return TestReconcilationState.Unknown; }
     return results.status; 
   }
 
-  stateForTestAssertion(file:vscode.Uri, name:string): TestAssertionStatus | null {
-    const results: TestFileAssertionStatus = this.fileStatuses[file.fsPath];
+  stateForTestAssertion(file:string, name:string): TestAssertionStatus | null {
+    const results: TestFileAssertionStatus = this.fileStatuses[file];
     if (!results) { return null; }
     const assertion = results.assertions.find((a) => a.title === name );
     if (!assertion) { return null; }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,30 @@
+'use strict';
+
+export interface JestFileResults {
+    name: string;
+    summary: string;
+    message: string;
+    status: "failed" | "passed";
+    startTime:number;
+    endTime:number;
+    assertionResults: JestAssertionResults[];
+}
+
+export interface JestAssertionResults {
+    name: string;
+    title: string;
+    status: "failed" | "passed";
+    failureMessages: string[];
+}
+
+export interface JestTotalResults {
+    success:boolean;
+    startTime:number;
+    numTotalTests:number;
+    numTotalTestSuites:number;
+    numRuntimeErrorTestSuites:number;
+    numPassedTests:number;
+    numFailedTests:number;
+    numPendingTests:number;
+    testResults: JestFileResults[];
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,0 @@
-import {workspace} from 'vscode';
-
-export function getPathToJest() {
-	return workspace.getConfiguration('jest').get('pathToJest');
-}
-
-export function shouldStartOnActivate() {
-	return workspace.getConfiguration('jest').get('watchOnProjectOpen');
-}

--- a/test/json_reader.test.ts
+++ b/test/json_reader.test.ts
@@ -1,6 +1,5 @@
 import * as assert from 'assert';
-import * as vscode from 'vscode';
-import { TestReconciler, TestReconcilationState } from '../src/test_reconciler';
+import { TestReconciler, TestReconcilationState } from '../src/lib/test_reconciler';
 import * as fs from "fs";
 
 const reconcilerWithFile = (file: string): TestReconciler => {
@@ -14,22 +13,18 @@ const reconcilerWithFile = (file: string): TestReconciler => {
 suite("Test Reconciler", () => {
     let parser: TestReconciler;
     const dangerFilePath = "/Users/orta/dev/projects/danger/danger-js/source/ci_source/_tests/_travis.test.js";
-    const dangerFile = vscode.Uri.file(dangerFilePath);
-
-    const metapFilePath = "/Users/orta/dev/projects/danger/danger-js/source/ci_source/_tests/_travis.test.js";
-    const metapFile = vscode.Uri.file(metapFilePath);
 
     suite("for a simple project", () => {
       test("passes a passing method", () => {
         parser = reconcilerWithFile("failing_jest_json.json");
-        const status = parser.stateForTestAssertion(dangerFile, "does not validate without josh");
+        const status = parser.stateForTestAssertion(dangerFilePath, "does not validate without josh");
         assert.equal(status.status, TestReconcilationState.KnownSuccess);
         assert.equal(status.line, null);
       });
 
       test("fails a failing method in the same file", () => {
         parser = reconcilerWithFile("failing_jest_json.json");
-        const status = parser.stateForTestAssertion(dangerFile, "validates when all Travis environment vars are set and Josh K says so");
+        const status = parser.stateForTestAssertion(dangerFilePath, "validates when all Travis environment vars are set and Josh K says so");
         assert.equal(status.status, TestReconcilationState.KnownFail);
         assert.equal(status.line, 12);
         assert.equal(status.terseMessage, "Expected value to be falsy, instead received true");

--- a/test/test_file_parser.test.ts
+++ b/test/test_file_parser.test.ts
@@ -1,17 +1,12 @@
 // The module 'assert' provides assertion methods from node
 import * as assert from 'assert';
 
-// You can import and use all API from the 'vscode' module
-// as well as import your extension to test it
-import * as vscode from 'vscode';
-import * as myExtension from '../src/extension';
-
-import { TestFileParser } from '../src/test_file_parser';
+import { TestFileParser } from '../src/lib/test_file_parser';
 
 suite("File Parsing", () => {
 
     test("For the simplest global case", async () => {
-        let parser = new TestFileParser(null);
+        let parser = new TestFileParser();
         await parser.run(__dirname + "/../../test/fixtures/global_its.js");
         assert.equal(parser.itBlocks.length, 2);
         
@@ -27,7 +22,7 @@ suite("File Parsing", () => {
     });
     
     test("For its inside describes", async () => {
-        let parser = new TestFileParser(null);
+        let parser = new TestFileParser();
         await parser.run(__dirname + "/../../test/fixtures/nested_its.js");
         assert.equal(parser.itBlocks.length, 3);
         
@@ -48,19 +43,19 @@ suite("File Parsing", () => {
     });
 
     test("For a danger test file (which has flow annotations)", async () => {
-        let parser = new TestFileParser(null);
+        let parser = new TestFileParser();
         await parser.run(__dirname + "/../../test/fixtures/dangerjs/travis-ci.jstest.js");
         assert.equal(parser.itBlocks.length, 7);
     });
 
     test("For a metaphysics test file", async () => {
-        let parser = new TestFileParser(null);
+        let parser = new TestFileParser();
         await parser.run(__dirname + "/../../test/fixtures/metaphysics/partner_show.js");
         assert.equal(parser.itBlocks.length, 8);
     });
 
     test("For a danger flow test file ", async () => {
-        let parser = new TestFileParser(null);
+        let parser = new TestFileParser();
         await parser.run(__dirname + "/../../test/fixtures/dangerjs/github.jstest.js");
         assert.equal(parser.itBlocks.length, 2);
     });


### PR DESCRIPTION
Handles the:

>  Start to decouple VS Code from the codebase. This means only Extension.ts is allowed to use import {workspace} from 'vscode'; as a bare minimum.

part of this issue - https://github.com/facebook/jest/issues/2183

---

The `src/lib` directory is effectively self contained now, and does not have any references to VS Code. Making it available for Nuclide usage. 

/cc @cpojer 