### PR TITLE
Allow VSCode for Jest to run when you work inside a lerna repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Separation of VS Code specific code from the extension by creating a lib directory, 
   in prepration for moving to the Jest repo - https://github.com/facebook/jest/issues/2183 - orta
 * Minor improvements for create-react users - orta
+* Support for running Jest even in repos where Jest is not a direct dependency via the command `Start Jest Runner` - you will definitely need to set the per-project `.vscode/settings.json` to whatever would normally trigger a jest run - orta 
 
 ### 1.5.1
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   ],
   "activationEvents": [
     "workspaceContains:node_modules/.bin/jest",
-    "workspaceContains:node_modules/react-scripts/node_modules/.bin/jest"
+    "workspaceContains:node_modules/react-scripts/node_modules/.bin/jest",
+    "onCommand:io.orta.jest.start"
   ],
   "main": "./out/src/extension",
   "icon": "images/vscode-jest.png",
@@ -52,7 +53,7 @@
           "default": true
         },
         "jest.pathToJest": {
-          "title": "The path to the Jest binary",
+          "title": "The path to the Jest binary, or an npm command to run tests prefixed with `--` e.g. `npm test --`",
           "type": "string",
           "default": "node_modules/.bin/jest"
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,10 +17,6 @@ var extensionInstance: JestExt;
 
 // Typing the actual JSON we get from Jest's runner
 
-// TODO: These need to be in lib
-
-
-
 export function activate(context: vscode.ExtensionContext) {
     // To make us VS Code agnostic outside of this file
     const jestPath = pathToJest();
@@ -45,12 +41,12 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("io.orta.show-jest-output", ()=> {
         channel.show();
     });
-
-    vscode.commands.registerCommand("io.orta.jest.start", ()=> {
+    vscode.commands.registerTextEditorCommand("io.orta.jest.start", ()=> {
+        vscode.window.showInformationMessage("Started Jest");
         extensionInstance.startProcess();
     });
 
-    vscode.commands.registerCommand("io.orta.jest.stop", ()=> {
+    vscode.commands.registerTextEditorCommand("io.orta.jest.stop", ()=> {
         extensionInstance.stopProcess();
     });
 


### PR DESCRIPTION
Now if you're in a project whose NPM modules are a tad ambiguous, you can use a command to start up the extension.

![screen shot 2016-11-30 at 11 50 06](https://cloud.githubusercontent.com/assets/49038/20751370/4b0a950a-b6f3-11e6-837f-fd23416ed532.png)