### PR TITLE
break code into smaller modules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,6 @@
         "out": true // set this to false to include "out" folder in search results
     },
     "typescript.tsdk": "./node_modules/typescript/lib", // we want to use the TS server from our node_modules folder to control its version
-    "eslint.enable": false
+    "eslint.enable": false,
+    "tslint.autoFixOnSave": true
 }

--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -1,0 +1,365 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+
+import { JestTotalResults } from './lib/types';
+import {
+    Expect,
+    ItBlock,
+    Runner,
+    Settings,
+    ProjectWorkspace,
+    parse,
+    TestReconciler,
+    IParseResults
+} from 'jest-editor-support';
+
+import * as decorations from './decorations';
+
+type TestReconcilationState = 'Unknown' |
+    'KnownSuccess' |
+    'KnownFail';
+const TestReconcilationState = {
+    Unknown: 'Unknown' as TestReconcilationState,
+    KnownSuccess: 'KnownSuccess' as TestReconcilationState,
+    KnownFail: 'KnownFail' as TestReconcilationState,
+};
+
+export class JestExt {
+    private workspace: ProjectWorkspace;
+    private jestProcess: Runner;
+    private jestSettings: Settings;
+    private reconciler: TestReconciler;
+
+    // So you can read what's going on
+    private channel: vscode.OutputChannel;
+
+    // The bottom status bar
+    private statusBarItem: vscode.StatusBarItem;
+    // The ability to show fails in the problems section
+    private failDiagnostics: vscode.DiagnosticCollection;
+
+    private passingItStyle: vscode.TextEditorDecorationType;
+    private failingItStyle: vscode.TextEditorDecorationType;
+    private unknownItStyle: vscode.TextEditorDecorationType;
+
+    private parsingTestFile = false;
+    private parseResults: IParseResults = {
+        expects: [],
+        itBlocks: []
+    };
+
+    // We have to keep track of our inline assert fails to remove later 
+    private failingAssertionDecorators: vscode.TextEditorDecorationType[];
+
+    private clearOnNextInput: boolean;
+
+    constructor(workspace: ProjectWorkspace, outputChannel: vscode.OutputChannel) {
+        this.workspace = workspace;
+        this.channel = outputChannel;
+        this.failingAssertionDecorators = [];
+        this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+        this.failDiagnostics = vscode.languages.createDiagnosticCollection('Jest');
+        this.clearOnNextInput = true;
+        this.reconciler = new TestReconciler();
+        this.jestSettings = new Settings(workspace);
+
+        this.getSettings(settings => {
+            workspace.localJestMajorVersion = settings.jestVersionMajor;
+
+            // If we should start the process by default, do so
+            const userJestSettings: any = vscode.workspace.getConfiguration('jest');
+            if (userJestSettings.autoEnable) {
+                this.startProcess();
+            } else {
+                this.channel.appendLine('Skipping initial Jest runner process start.');
+            }
+        });
+    }
+
+    public startProcess = () => {
+        // The Runner is an event emitter that handles taking the Jest
+        // output and converting it into different types of data that
+        // we can handle here differently.
+
+        this.jestProcess = new Runner(this.workspace);
+
+        this.jestProcess.on('debuggerComplete', () => {
+            this.channel.appendLine('Closed Jest');
+        }).on('executableJSON', (data: any) => {
+            this.updateWithData(data);
+            this.triggerUpdateDecorations(vscode.window.activeTextEditor);
+            this.clearOnNextInput = true;
+        }).on('executableOutput', (output: string) => {
+            if (!output.includes('Watch Usage')) {
+                this.channel.appendLine(output);
+            }
+        }).on('executableStdErr', (error: Buffer) => {
+            // The "tests are done" message comes through stdErr
+            // We want to use this as a marker that the console should
+            // be cleared, as the next input will be from a new test run.
+
+            if (this.clearOnNextInput) {
+                this.clearOnNextInput = false;
+                this.parsingTestFile = false;
+                this.testsHaveStartedRunning();
+            }
+            const message = error.toString();
+            // thanks Qix, http://stackoverflow.com/questions/25245716/remove-all-ansi-colors-styles-from-strings
+            const noANSI = message.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '');
+
+            if (noANSI.includes('snapshot test failed')) {
+                this.detectedSnapshotErrors();
+            }
+
+            this.channel.appendLine(noANSI);
+        }).on('nonTerminalError', (error: string) => {
+            this.channel.appendLine(`Recieved an error from Jest Runner: ${error.toString()}`);
+        }).on('exception', result => {
+            this.channel.appendLine(`\nException raised: [${result.type}]: ${result.message}\n`);
+        }).on('terminalError', (error: string) => {
+            this.channel.appendLine('\nException raised: ' + error);
+        });
+
+        // The theme stuff
+        this.setupDecorators();
+        // The bottom bar thing
+        this.setupStatusBar();
+        // Go!
+        this.jestProcess.start();
+    }
+
+    public stopProcess = () => {
+        this.channel.appendLine('Closing Jest jest_runner.');
+        this.jestProcess.closeProcess();
+    }
+
+    private getSettings = (completed: (settings: Settings) => void) => {
+        this.jestSettings.getConfig(() => {
+            if (this.jestSettings.jestVersionMajor < 18) {
+                vscode.window.showErrorMessage('This extension relies on Jest 18+ features, it will work, but the highlighting may not work correctly.');
+            }
+            completed(this.jestSettings);
+        });
+    }
+
+    private wouldJestRunURI = (uri: vscode.Uri) => {
+        const testRegex = new RegExp(this.jestSettings.settings.testRegex);
+        const root = vscode.workspace.rootPath;
+        const filePath = uri.fsPath;
+        let relative = path.normalize(path.relative(root, filePath));
+        // replace windows path separator with normal slash
+        if (path.sep === '\\') {
+            relative = relative.replace(/\\/g, '/');
+        }
+
+        const matches = relative.match(testRegex);
+
+        return matches && matches.length > 0;
+    }
+
+    private detectedSnapshotErrors = () => {
+        vscode.window.showInformationMessage('Would you like to update your Snapshots?', { title: 'Replace them' }).then((response) => {
+            // No response == cancel
+            if (response) {
+                this.jestProcess.runJestWithUpdateForSnapshots(() => {
+                    vscode.window.showInformationMessage('Updated Snapshots. It will show in your next test run.');
+                });
+            }
+        });
+    }
+
+    public triggerUpdateDecorations(editor: vscode.TextEditor) {
+        // Lots of reasons to not show decorators,
+        // Are you at the empty screen?
+        if (!editor) { return; }
+        // Are you in settings?
+        if (!editor.document) { return; }
+        // Is it already happening?
+        if (this.parsingTestFile) { return; }
+        // is it in the test regex?
+        if (!this.wouldJestRunURI(editor.document.uri)) { return; }
+        // OK - lets go
+        this.parsingTestFile = true;
+
+        // This makes it cheaper later down the line
+        let successes: Array<ItBlock> = [];
+        let fails: Array<ItBlock> = [];
+        let unknowns: Array<ItBlock> = [];
+
+        // Parse the current JS file
+        this.parseResults = parse(editor.document.uri.fsPath);
+        // Use the parsers it blocks for references
+        const { itBlocks } = this.parseResults;
+
+        // Loop through our it/test references, then ask the reconciler ( the thing 
+        // that reads the JSON from Jest ) whether it has passed/failed/not ran.
+        const filePath = editor.document.uri.fsPath;
+        const fileState = this.reconciler.stateForTestFile(filePath);
+        switch (fileState) {
+            // If the file failed, then it can contain passes, fails and unknowns
+            case TestReconcilationState.KnownFail:
+                itBlocks.forEach(it => {
+                    const state = this.reconciler.stateForTestAssertion(filePath, it.name);
+                    if (state !== null) {
+                        switch (state.status) {
+                            case TestReconcilationState.KnownSuccess:
+                                successes.push(it); break;
+                            case TestReconcilationState.KnownFail:
+                                fails.push(it); break;
+                            case TestReconcilationState.Unknown:
+                                unknowns.push(it); break;
+                        }
+                    } else {
+                        unknowns.push(it);
+                    }
+                });
+                break;
+            // Test passed, all it's must be green
+            case TestReconcilationState.KnownSuccess:
+                successes = itBlocks; break;
+
+            // We don't know, not ran probably
+            case TestReconcilationState.Unknown:
+                unknowns = itBlocks; break;
+        };
+
+        // Create a map for the states and styles to show inline.
+        // Note that this specifically is only for dots.
+        const styleMap = [
+            { data: successes, style: this.passingItStyle, state: TestReconcilationState.KnownSuccess },
+            { data: fails, style: this.failingItStyle, state: TestReconcilationState.KnownFail },
+            { data: unknowns, style: this.unknownItStyle, state: TestReconcilationState.Unknown }
+        ];
+        styleMap.forEach(style => {
+            let decorators = this.generateDotsForItBlocks(style.data, style.state);
+            editor.setDecorations(style.style, decorators);
+        });
+
+        // Now we want to handle adding the error message after the failing assertion
+        // so first we need to clear all assertions, this is a bit of a shame as it can flash
+        // however, the API for a style in this case is not built to handle different inline texts 
+        // as easily as it handles inline dots
+
+        // Remove all of the existing line decorators
+        this.failingAssertionDecorators.forEach(element => {
+            editor.setDecorations(element, []);
+        });
+        this.failingAssertionDecorators = [];
+
+        // Loop through all the failing "Statuses" (these are files)
+        const failStatuses = this.reconciler.failedStatuses();
+        failStatuses.forEach((fail) => {
+            // Skip fails that aren't for this file
+            if (editor.document.uri.fsPath !== fail.file) { return; }
+
+            // Get the failed assertions
+            const asserts = fail.assertions.filter((a) => a.status === TestReconcilationState.KnownFail);
+            asserts.forEach((assertion) => {
+                const decorator = {
+                    range: new vscode.Range(assertion.line - 1, 0, 0, 0),
+                    hoverMessage: assertion.terseMessage
+                };
+                // We have to make a new style for each unique message, this is
+                // why we have to remove off of them beforehand
+                const style = decorations.failingAssertionStyle(assertion.terseMessage);
+                this.failingAssertionDecorators.push(style);
+                editor.setDecorations(style, [decorator]);
+            });
+        });
+        this.parsingTestFile = false;
+    }
+
+    private setupStatusBar = () => {
+        this.statusBarItem.show();
+        this.statusBarItem.command = 'io.orta.show-jest-output';
+
+        const jestSettings = vscode.workspace.getConfiguration('jest');
+        if (jestSettings['autoEnable']) {
+            this.testsHaveStartedRunning();
+        } else {
+            this.statusBarItem.text = 'Jest: ...';
+        }
+    }
+
+    private setupDecorators = () => {
+        this.passingItStyle = decorations.passingItName();
+        this.failingItStyle = decorations.failingItName();
+        this.unknownItStyle = decorations.notRanItName();
+    }
+
+    private testsHaveStartedRunning = () => {
+        this.channel.clear();
+        this.statusBarItem.text = 'Jest: $(sync)';
+    }
+
+    private updateWithData = (data: JestTotalResults) => {
+        this.reconciler.updateFileWithJestStatus(data);
+        this.failDiagnostics.clear();
+
+        if (data.success) {
+            this.statusBarItem.text = 'Jest: $(check)';
+
+        } else {
+            this.statusBarItem.text = 'Jest: $(alert)';
+
+            // We've got JSON data back from Jest about a failing test run.
+            // We don't want to handle the decorators (inline dots/messages here)
+            // but we can handle creating "problems" for the workspace here.
+
+            // For each failed file
+            const fails = this.reconciler.failedStatuses();
+            fails.forEach((fail) => {
+                // Generate a uri, and pull out the failing it/tests
+                const uri = vscode.Uri.file(fail.file);
+                const asserts = fail.assertions.filter((a) => a.status === TestReconcilationState.KnownFail);
+
+                // Loop through each individual fail and create an diagnostic
+                // to pass back to VS Code.
+                this.failDiagnostics.set(uri, asserts.map((assertion) => {
+                    const expect = this.expectAtLine(assertion.line);
+                    const start = expect ? expect.start.column - 1 : 0;
+                    const daig = new vscode.Diagnostic(
+                        new vscode.Range(assertion.line - 1, start, assertion.line - 1, start + 6),
+                        assertion.terseMessage,
+                        vscode.DiagnosticSeverity.Error
+                    );
+                    daig.source = 'Jest';
+                    return daig;
+                }));
+            });
+        }
+    }
+
+    private generateDotsForItBlocks = (blocks: ItBlock[], state: TestReconcilationState): vscode.DecorationOptions[] => {
+        const nameForState = (name: string, state: TestReconcilationState): string => {
+            switch (state) {
+                case TestReconcilationState.KnownSuccess:
+                    return 'Passed';
+                case TestReconcilationState.KnownFail:
+                    return 'Failed';
+                case TestReconcilationState.Unknown:
+                    return 'Test has not run yet, due to Jest only running tests related to changes.';
+            }
+        };
+        return blocks.map((it) => {
+            return {
+                // VS Code is indexed starting at 0
+                // jest-editor-support is indexed starting at 1
+                range: new vscode.Range(it.start.line - 1, it.start.column - 1, it.start.line - 1, it.start.column + 1),
+                hoverMessage: nameForState(it.name, state),
+            };
+        });
+    }
+
+    // When we want to show an inline assertion, the only bit of
+    // data to work with is the line number from the stack trace.
+    // So we need to be able to go from that to the real
+    // expect data.
+    private expectAtLine = (line: number): null | Expect => {
+        return this.parseResults.expects.find((e) => e.start.line === line);
+    }
+
+    public deactivate = () => {
+        this.jestProcess.closeProcess();
+    }
+}

--- a/src/decorations.ts
+++ b/src/decorations.ts
@@ -8,14 +8,14 @@ export function failingItName() {
         overviewRulerLane: vscode.OverviewRulerLane.Left,
         light: {
             before: {
-                color: "#FF564B",
-                contentText: "●",
+                color: '#FF564B',
+                contentText: '●',
             }
         },
         dark: {
             before: {
-                color: "#AD322D",
-                contentText: "●",
+                color: '#AD322D',
+                contentText: '●',
             }
         }
     });
@@ -27,14 +27,14 @@ export function passingItName() {
         overviewRulerLane: vscode.OverviewRulerLane.Left,
         light: {
             before: {
-                color: "#3BB26B",
-                contentText: "●" 
+                color: '#3BB26B',
+                contentText: '●' 
             }
         },
         dark: {
             before: {
-                color: "#2F8F51",
-                contentText: "●",
+                color: '#2F8F51',
+                contentText: '●',
             }
         }
     });
@@ -46,14 +46,14 @@ export function notRanItName() {
         overviewRulerLane: vscode.OverviewRulerLane.Left,
         dark: {
             before: {
-                color: "#3BB26B",
-                contentText: "○",
+                color: '#3BB26B',
+                contentText: '○',
             }    
         },
         light: {
             before: {
-                color: "#2F8F51",
-                contentText: "○",
+                color: '#2F8F51',
+                contentText: '○',
             }    
         }
     });
@@ -67,16 +67,16 @@ export function failingAssertionStyle(text: string) {
         overviewRulerLane: vscode.OverviewRulerLane.Left,
         light: {
             before: {
-                color: "#FF564B",
+                color: '#FF564B',
             }
         },
         dark: {
             before: {
-                color: "#AD322D",
+                color: '#AD322D',
             }
         },
         after: {
-            contentText: " // " + text
+            contentText: ' // ' + text
         }
     });
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,75 +1,39 @@
-'use strict';
-
 import * as vscode from 'vscode';
-import * as path from 'path';
+import { ProjectWorkspace } from 'jest-editor-support';
 
-type TestReconcilationState = "Unknown" |
-"KnownSuccess" |
-"KnownFail";
-const TestReconcilationState = {
-    Unknown: "Unknown" as TestReconcilationState,
-    KnownSuccess: "KnownSuccess" as TestReconcilationState,
-    KnownFail: "KnownFail" as TestReconcilationState,
-};
-
-import { JestTotalResults } from './lib/types';
-import {
-    Expect,
-    ItBlock,
-    Runner,
-    Settings,
-    ProjectWorkspace,
-    parse,
-    TestReconciler,
-    IParseResults
-} from 'jest-editor-support';
-
-import * as decorations from './decorations';
 import { pathToJest, pathToConfig } from './helpers';
+import { JestExt } from './JestExt';
 
-var extensionInstance: JestExt;
-
-// Typing the actual JSON we get from Jest's runner
+let extensionInstance: JestExt;
 
 export function activate(context: vscode.ExtensionContext) {
     // To make us VS Code agnostic outside of this file
     const jestPath = pathToJest();
     const configPath = pathToConfig(); 
-    const currentJestVersion = 18
+    const currentJestVersion = 18;
     const workspace = new ProjectWorkspace(vscode.workspace.rootPath, jestPath, configPath, currentJestVersion);
 
     // Create our own console
-    const channel = vscode.window.createOutputChannel("Jest");
+    const channel = vscode.window.createOutputChannel('Jest');
 
     // We need a singleton to represent the extension
-    extensionInstance = new JestExt(workspace, channel, context.subscriptions);
-    extensionInstance.getSettings((settings: Settings) => {
-        workspace.localJestMajorVersion = settings.jestVersionMajor
-
-        // If we should start the process by default, do so
-        const userJestSettings: any = vscode.workspace.getConfiguration("jest");
-        if (userJestSettings.autoEnable) {
-            extensionInstance.startProcess();
-        } else {
-            channel.appendLine("Skipping initial Jest runner process start.");
-        }
-    });
+    extensionInstance = new JestExt(workspace, channel);
 
     // Register for commands   
-    vscode.commands.registerCommand("io.orta.show-jest-output", () => {
+    vscode.commands.registerCommand('io.orta.show-jest-output', () => {
         channel.show();
     });
-    vscode.commands.registerTextEditorCommand("io.orta.jest.start", ()=> {
-        vscode.window.showInformationMessage("Started Jest, press escape to hide this message.");
+    vscode.commands.registerTextEditorCommand('io.orta.jest.start', ()=> {
+        vscode.window.showInformationMessage('Started Jest, press escape to hide this message.');
         extensionInstance.startProcess();
     });
 
-    vscode.commands.registerTextEditorCommand("io.orta.jest.stop", ()=> {
+    vscode.commands.registerTextEditorCommand('io.orta.jest.stop', ()=> {
         extensionInstance.stopProcess();
     });
 
     // Setup the file change watchers
-    var activeEditor = vscode.window.activeTextEditor;
+    let activeEditor = vscode.window.activeTextEditor;
     if (activeEditor) {
         extensionInstance.triggerUpdateDecorations(activeEditor);
     }
@@ -90,351 +54,9 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.workspace.onDidChangeTextDocument(event => {
         if (activeEditor && event.document === activeEditor.document) {
             extensionInstance.triggerUpdateDecorations(activeEditor);
-
         }
     }, null, context.subscriptions);
 
-}
-
-class JestExt {
-    private workspace: ProjectWorkspace;
-    private jestProcess: Runner;
-    private jestSettings: Settings;
-    private reconciler: TestReconciler;
-
-    // So you can read what's going on
-    private channel: vscode.OutputChannel;
-
-    // Memory management
-    private workspaceDisposal: { dispose(): any }[];
-    private perFileDisposals: { dispose(): any }[];
-
-    // The bottom status bar
-    private statusBarItem: vscode.StatusBarItem;
-    // The ability to show fails in the problems section
-    private failDiagnostics: vscode.DiagnosticCollection;
-
-    private passingItStyle: vscode.TextEditorDecorationType;
-    private failingItStyle: vscode.TextEditorDecorationType;
-    private unknownItStyle: vscode.TextEditorDecorationType;
-
-    // We have to keep track of our inline assert fails to remove later 
-    private failingAssertionDecorators: any[];
-
-    private clearOnNextInput: boolean;
-
-    public constructor(workspace: ProjectWorkspace, outputChannel: vscode.OutputChannel, disposal: { dispose(): any }[]) {
-        this.workspace = workspace;
-        this.channel = outputChannel;
-        this.workspaceDisposal = disposal;
-        this.perFileDisposals = [];
-        this.failingAssertionDecorators = [];
-        this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
-        this.failDiagnostics = vscode.languages.createDiagnosticCollection("Jest");
-        this.clearOnNextInput = true;
-        this.reconciler = new TestReconciler();
-        this.jestSettings = new Settings(workspace);
-    }
-
-    startProcess = () => {
-        // The Runner is an event emitter that handles taking the Jest
-        // output and converting it into different types of data that
-        // we can handle here differently.
-
-        this.jestProcess = new Runner(this.workspace);
-
-        this.jestProcess.on('debuggerComplete', () => {
-            this.channel.appendLine("Closed Jest");
-
-        }).on('executableJSON', (data: any) => {
-            this.updateWithData(data);
-            this.triggerUpdateDecorations(vscode.window.activeTextEditor);
-            this.clearOnNextInput = true;
-
-        }).on('executableOutput', (output: string) => {
-            if (!output.includes("Watch Usage")) {
-                this.channel.appendLine(output);
-            }
-        }).on('executableStdErr', (error: Buffer) => {
-            // The "tests are done" message comes through stdErr
-            // We want to use this as a marker that the console should
-            // be cleared, as the next input will be from a new test run.
-
-            if (this.clearOnNextInput) {
-                this.clearOnNextInput = false;
-                this.parsingTestFile = false;
-                this.testsHaveStartedRunning();
-            }
-            const message = error.toString();
-            // thanks Qix, http://stackoverflow.com/questions/25245716/remove-all-ansi-colors-styles-from-strings
-            const noANSI = message.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '');
-
-            if (noANSI.includes("snapshot test failed")) {
-                this.detectedSnapshotErrors();
-            }
-
-            this.channel.appendLine(noANSI);
-        }).on('nonTerminalError', (error: string) => {
-            this.channel.appendLine(`Recieved an error from Jest Runner: ${error.toString()}`);
-        }).on('exception', result => {
-            this.channel.appendLine("\nException raised: [" + result.type + "]: " + result.message + "\n");
-        }).on('terminalError', (error: string) => {
-            this.channel.appendLine("\nException raised: " + error);
-        });
-
-        // The theme stuff
-        this.setupDecorators();
-        // The bottom bar thing
-        this.setupStatusBar();
-        // Go!
-        this.jestProcess.start();
-    }
-
-    stopProcess = () => {
-        this.channel.appendLine("Closing Jest jest_runner.");
-        this.jestProcess.closeProcess();
-    }
-
-    // Get the settings from Jest's JSON output
-    getSettings = (completed: any) => {
-        this.jestSettings.getConfig(() => {
-            if (this.jestSettings.jestVersionMajor < 18) {
-                vscode.window.showErrorMessage("This extension relies on Jest 18+ features, it will work, but the highlighting may not work correctly.");
-            }
-            completed(this.jestSettings);
-        });
-    }
-
-    wouldJestRunURI = (uri: vscode.Uri): boolean => {
-        const testRegex = new RegExp(this.jestSettings.settings.testRegex);
-        const root = vscode.workspace.rootPath;
-        const filePath = uri.fsPath;
-        let relative = path.normalize(path.relative(root, filePath));
-        // replace windows path separator with normal slash
-        if (path.sep === '\\') {
-            relative = relative.replace(/\\/g, '/');
-        }
-
-        const matches = relative.match(testRegex);
-
-        return matches && matches.length > 0;
-    }
-
-    detectedSnapshotErrors = () => {
-        vscode.window.showInformationMessage("Would you like to update your Snapshots?", { title: "Replace them" }).then((response) => {
-            // No response == cancel
-            if (response) {
-                this.jestProcess.runJestWithUpdateForSnapshots(() => {
-                    vscode.window.showInformationMessage("Updated Snapshots. It will show in your next test run.");
-                });
-            }
-        });
-    }
-
-    private parsingTestFile = false;
-    private parseResults: IParseResults = {
-        expects: [],
-        itBlocks: []
-    };
-    async triggerUpdateDecorations(editor: vscode.TextEditor) {
-        // Lots of reasons to not show decorators,
-        // Are you at the empty screen?
-        if (!editor) { return; }
-        // Are you in settings?
-        if (!editor.document) { return; }
-        // Is it already happening?
-        if (this.parsingTestFile) { return; }
-        // is it in the test regex?
-        if (!this.wouldJestRunURI(editor.document.uri)) { return; }
-        // OK - lets go
-        this.parsingTestFile = true;
-
-        // This makes it cheaper later down the line
-        let successes: Array<ItBlock> = [];
-        let fails: Array<ItBlock> = [];
-        let unknowns: Array<ItBlock> = [];
-
-
-        // Parse the current JS file
-        this.parseResults = parse(editor.document.uri.fsPath);
-        // Use the parsers it blocks for references
-        const itBlocks = this.parseResults.itBlocks;
-
-        // Loop through our it/test references, then ask the reconciler ( the thing 
-        // that reads the JSON from Jest ) whether it has passed/failed/not ran.
-        const filePath = editor.document.uri.fsPath;
-        const fileState = this.reconciler.stateForTestFile(filePath);
-        switch (fileState) {
-            // If the file failed, then it can contain passes, fails and unknowns
-            case TestReconcilationState.KnownFail:
-                itBlocks.forEach(it => {
-                    const state = this.reconciler.stateForTestAssertion(filePath, it.name);
-                    if (state !== null) {
-                        switch (state.status) {
-                            case TestReconcilationState.KnownSuccess:
-                                successes.push(it); break;
-                            case TestReconcilationState.KnownFail:
-                                fails.push(it); break;
-                            case TestReconcilationState.Unknown:
-                                unknowns.push(it); break;
-                        }
-                    } else {
-                        unknowns.push(it);
-                    }
-                });
-                break;
-            // Test passed, all it's must be green
-            case TestReconcilationState.KnownSuccess:
-                successes = itBlocks; break;
-
-            // We don't know, not ran probably
-            case TestReconcilationState.Unknown:
-                unknowns = itBlocks; break;
-        };
-
-
-
-        // Create a map for the states and styles to show inline.
-        // Note that this specifically is only for dots.
-        const styleMap = [
-            { data: successes, style: this.passingItStyle, state: TestReconcilationState.KnownSuccess },
-            { data: fails, style: this.failingItStyle, state: TestReconcilationState.KnownFail },
-            { data: unknowns, style: this.unknownItStyle, state: TestReconcilationState.Unknown }
-        ];
-        styleMap.forEach(style => {
-            let decorators = this.generateDecoratorsForJustIt(style.data, style.state);
-            editor.setDecorations(style.style, decorators);
-        });
-
-        // Now we want to handle adding the error message after the failing assertion
-        // so first we need to clear all assertions, this is a bit of a shame as it can flash
-        // however, the API for a style in this case is not built to handle different inline texts 
-        // as easily as it handles inline dots
-
-        // Remove all of the existing line decorators
-        this.failingAssertionDecorators.forEach(element => {
-            editor.setDecorations(element, []);
-        });
-        this.failingAssertionDecorators = [];
-
-        // Loop through all the failing "Statuses" (these are files)
-        const failStatuses = this.reconciler.failedStatuses();
-        failStatuses.forEach((fail) => {
-            // Skip fails that aren't for this file
-            if (editor.document.uri.fsPath !== fail.file) { return; }
-
-            // Get the failed assertions
-            const asserts = fail.assertions.filter((a) => a.status === TestReconcilationState.KnownFail);
-            asserts.forEach((assertion) => {
-                const decorator = {
-                    range: new vscode.Range(assertion.line - 1, 0, 0, 0),
-                    hoverMessage: assertion.terseMessage
-                };
-                // We have to make a new style for each unique message, this is
-                // why we have to remove off of them beforehand
-                const style = decorations.failingAssertionStyle(assertion.terseMessage);
-                this.failingAssertionDecorators.push(style);
-                editor.setDecorations(style, [decorator]);
-            });
-        });
-        this.parsingTestFile = false;
-    }
-
-    setupStatusBar = () => {
-        this.statusBarItem.show();
-        this.statusBarItem.command = "io.orta.show-jest-output";
-
-        const jestSettings = vscode.workspace.getConfiguration("jest");
-        if (jestSettings["autoEnable"]) {
-            this.testsHaveStartedRunning();
-        } else {
-            this.statusBarItem.text = "Jest: ...";
-        }
-    }
-
-    setupDecorators = () => {
-        this.passingItStyle = decorations.passingItName();
-        this.failingItStyle = decorations.failingItName();
-        this.unknownItStyle = decorations.notRanItName();
-    }
-
-    testsHaveStartedRunning = () => {
-        this.channel.clear();
-        this.statusBarItem.text = "Jest: $(sync)";
-    }
-
-    updateWithData = (data: JestTotalResults) => {
-        this.reconciler.updateFileWithJestStatus(data);
-        this.failDiagnostics.clear();
-
-        if (data.success) {
-            this.statusBarItem.text = "Jest: $(check)";
-
-        } else {
-            this.statusBarItem.text = "Jest: $(alert)";
-
-            // We've got JSON data back from Jest about a failing test run.
-            // We don't want to handle the decorators (inline dots/messages here)
-            // but we can handle creating "problems" for the workspace here.
-
-            // For each failed file
-            const fails = this.reconciler.failedStatuses();
-            fails.forEach((fail) => {
-                // Generate a uri, and pull out the failing it/tests
-                const uri = vscode.Uri.file(fail.file);
-                const asserts = fail.assertions.filter((a) => a.status === TestReconcilationState.KnownFail);
-
-                // Loop through each individual fail and create an diagnostic
-                // to pass back to VS Code.
-                this.failDiagnostics.set(uri, asserts.map((assertion) => {
-                    const expect = this.expectAtLine(assertion.line);
-                    const start = expect ? expect.start.column - 1 : 0;
-                    const daig = new vscode.Diagnostic(
-                        new vscode.Range(assertion.line - 1, start, assertion.line - 1, start + 6),
-                        assertion.terseMessage,
-                        vscode.DiagnosticSeverity.Error
-                    );
-                    daig.source = "Jest";
-                    return daig;
-                }));
-            });
-        }
-    }
-
-    // These are the dots
-    generateDecoratorsForJustIt = (blocks: ItBlock[], state: TestReconcilationState): vscode.DecorationOptions[] => {
-        const nameForState = (name: string, state: TestReconcilationState): string => {
-            switch (state) {
-                case TestReconcilationState.KnownSuccess:
-                    return 'Passed';
-                case TestReconcilationState.KnownFail:
-                    return 'Failed';
-                case TestReconcilationState.Unknown:
-                    return 'Test has not run yet, due to Jest only running tests related to changes.';
-            }
-        };
-        return blocks.map((it) => {
-            return {
-                // VS Code is indexed starting at 0
-                // jest-editor-support is indexed starting at 1
-                range: new vscode.Range(it.start.line - 1, it.start.column - 1, it.start.line - 1, it.start.column + 1),
-                hoverMessage: nameForState(it.name, state),
-            };
-        });
-    }
-    
-    // When we want to show an inline assertion, the only bit of
-    // data to work with is the line number from the stack trace.
-
-    // So we need to be able to go from that to the real
-    // expect data.
-    expectAtLine = (line: number): null | Expect => {
-        return this.parseResults.expects.find((e) => e.start.line === line);
-    }
-
-    deactivate = () => {
-        this.jestProcess.closeProcess();
-    }
 }
 
 export function deactivate() {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -9,23 +9,23 @@ import {normalize} from 'path';
  * @returns {string}
  */
 export function pathToJest(): string {
-  const jestSettings: any = workspace.getConfiguration("jest");
+  const jestSettings: any = workspace.getConfiguration('jest');
   const path = normalize(jestSettings.pathToJest);
 
-  const defaultPath = normalize("node_modules/.bin/jest"); 
+  const defaultPath = normalize('node_modules/.bin/jest'); 
   if (path === defaultPath) {
-    const defaultCreateReactPath = "node_modules/react-scripts/node_modules/.bin/jest";
-    const defaultCreateReactPathWindows = "node_modules/react-scripts/node_modules/.bin/jest.cmd";
-    const createReactPath = (platform() === "win32") ? defaultCreateReactPathWindows : defaultCreateReactPath;
-    const absolutePath = workspace.rootPath + "/" + createReactPath;
+    const defaultCreateReactPath = 'node_modules/react-scripts/node_modules/.bin/jest';
+    const defaultCreateReactPathWindows = 'node_modules/react-scripts/node_modules/.bin/jest.cmd';
+    const createReactPath = (platform() === 'win32') ? defaultCreateReactPathWindows : defaultCreateReactPath;
+    const absolutePath = workspace.rootPath + '/' + createReactPath;
     if (!existsSync(path) && existsSync(absolutePath)) {
       // If it's the default, run the script instead
-      return (platform() === "win32") ? "npm.cmd test --" : "npm test --";
+      return (platform() === 'win32') ? 'npm.cmd test --' : 'npm test --';
     }
   }
 
   // For windows support, see https://github.com/orta/vscode-jest/issues/10
-  if (!path.includes(".cmd") && platform() === "win32") { return path + ".cmd";  }
+  if (!path.includes('.cmd') && platform() === 'win32') { return path + '.cmd';  }
   return path;
 }
 
@@ -35,11 +35,11 @@ export function pathToJest(): string {
  * @returns {string}
  */
 export function pathToConfig(): string {
-  const jestSettings: any = workspace.getConfiguration("jest");
+  const jestSettings: any = workspace.getConfiguration('jest');
 
-  if (jestSettings.pathToConfig !== "") {
+  if (jestSettings.pathToConfig !== '') {
     return normalize(jestSettings.pathToConfig);
   }
 
-  return "";
+  return '';
 } 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "alwaysStrict": true,
         "module": "commonjs",
         "target": "es6",
         "outDir": "out",
@@ -11,7 +12,6 @@
     },
     "exclude": [
         "node_modules",
-        ".vscode-test",
-        "_jest-editor"
+        ".vscode-test"
     ]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -3,6 +3,11 @@
 		"no-unused-expression": true,
 		"no-duplicate-variable": true,
 		"no-unused-variable": true,
+		"no-var-keyword": true,
+		"quotemark": [
+			true,
+			"single"
+		],
 		"curly": true,
 		"class-name": true,
 		"semicolon": ["never"],

--- a/typings/jest-editor-support.d.ts
+++ b/typings/jest-editor-support.d.ts
@@ -1,24 +1,24 @@
 declare module 'jest-editor-support' {
     import { EventEmitter } from 'events';
-    
+
     export class Runner extends EventEmitter {
         constructor(workspace: ProjectWorkspace);
         start(): void;
         closeProcess(): void;
         runJestWithUpdateForSnapshots(completion: any): void;
     }
-    
+
     export class Settings extends EventEmitter {
         constructor(workspace: ProjectWorkspace);
-        getConfig(completed: any): void;
+        getConfig(completed: Function): void;
         jestVersionMajor: number | null;
         settings: {
             testRegex: string;
         };
     }
-    
+
     export class ProjectWorkspace {
-        constructor(a, b, c, d);
+        constructor(rootPath: string, pathToJest: string, pathToConfig: string, localJestMajorVersin: number);
         pathToJest: string;
         rootPath: string;
         localJestMajorVersion: number;
@@ -28,15 +28,79 @@ declare module 'jest-editor-support' {
         expects: Expect[];
         itBlocks: ItBlock[];
     }
-    
+
     export function parse(file: string): IParseResults;
-    export type ItBlock = any;
-    export type Expect = any;
-    
+
+    type Location = {
+        column: number,
+        line: number,
+    };
+
+    class Node {
+        start: Location;
+        end: Location;
+        file: string;
+    }
+
+    export class ItBlock extends Node {
+        name: string;
+    }
+
+    export type Expect = Node;
+
     export class TestReconciler {
-        stateForTestFile(file: string): any;
-        stateForTestAssertion(file: string, name: string): any;
-        failedStatuses(): any;
+        stateForTestFile(file: string): TestReconcilationState;
+        stateForTestAssertion(file: string, name: string): TestFileAssertionStatus | null;
+        failedStatuses(): Array<TestFileAssertionStatus>;
         updateFileWithJestStatus(data): void;
+    }
+
+    type TestReconcilationState = "Unknown" |
+        "KnownSuccess" |
+        "KnownFail";
+
+    export type TestFileAssertionStatus = {
+        file: string,
+        message: string,
+        status: TestReconcilationState,
+        assertions: Array<TestAssertionStatus>,
+    }
+
+    export type TestAssertionStatus = {
+        title: string,
+        status: TestReconcilationState,
+        message: string,
+        shortMessage?: string,
+        terseMessage?: string,
+        line?: number,
+    }
+
+    export type JestFileResults = {
+        name: string,
+        summary: string,
+        message: string,
+        status: "failed" | "passed",
+        startTime: number,
+        endTime: number,
+        assertionResults: Array<JestAssertionResults>,
+    }
+
+    export type JestAssertionResults = {
+        name: string,
+        title: string,
+        status: "failed" | "passed",
+        failureMessages: string[],
+    }
+
+    export type JestTotalResults = {
+        success: boolean,
+        startTime: number,
+        numTotalTests: number,
+        numTotalTestSuites: number,
+        numRuntimeErrorTestSuites: number,
+        numPassedTests: number,
+        numFailedTests: number,
+        numPendingTests: number,
+        testResults: Array<JestFileResults>,
     }
 }


### PR DESCRIPTION
I was thinking we could start to split up and isolate parts of the code.  If we get around to writing some tests, it'll go easier with smaller modules. (fyi I tried to use jest to test, but because of the vscode dependencies I had some issues)

Let me know what you think.  If it's good I'll keep going, otherwise we can talk through next steps.

So far I've only pulled the JestExt class out into it's own file.