### PR TITLE
wait for settings before executing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,6 @@
     },
     "typescript.tsdk": "./node_modules/typescript/lib", // we want to use the TS server from our node_modules folder to control its version
     "eslint.enable": false,
-    "tslint.autoFixOnSave": true
+    "tslint.autoFixOnSave": true,
+    "jest.pathToConfig": "./jest.json"
 }

--- a/jest.json
+++ b/jest.json
@@ -4,5 +4,5 @@
   "transform": {
     "^.+\\.ts$": "<rootDir>/scripts/preprocessor.js"
   },
-  "testRegex": "/tests/.*\\.ts$"
+  "testRegex": "tests/.*\\.ts$"
 }

--- a/src/IPluginSettings.ts
+++ b/src/IPluginSettings.ts
@@ -1,0 +1,6 @@
+export interface IPluginSettings {
+    autoEnable?: boolean;
+    pathToJest?: string;
+    pathToConfig?: string;
+    rootPath?: string;
+}

--- a/src/decorations.ts
+++ b/src/decorations.ts
@@ -1,11 +1,9 @@
-'use strict';
-
-import * as vscode from 'vscode';
+import { window, OverviewRulerLane } from 'vscode';
 
 export function failingItName() {
-    return vscode.window.createTextEditorDecorationType({
+    return window.createTextEditorDecorationType({
         overviewRulerColor: 'red',
-        overviewRulerLane: vscode.OverviewRulerLane.Left,
+        overviewRulerLane: OverviewRulerLane.Left,
         light: {
             before: {
                 color: '#FF564B',
@@ -22,9 +20,9 @@ export function failingItName() {
 }
 
 export function passingItName() {
-    return vscode.window.createTextEditorDecorationType({
+    return window.createTextEditorDecorationType({
         overviewRulerColor: 'green',
-        overviewRulerLane: vscode.OverviewRulerLane.Left,
+        overviewRulerLane: OverviewRulerLane.Left,
         light: {
             before: {
                 color: '#3BB26B',
@@ -41,9 +39,9 @@ export function passingItName() {
 }
 
 export function notRanItName() {
-    return vscode.window.createTextEditorDecorationType({
+    return window.createTextEditorDecorationType({
         overviewRulerColor: 'darkgrey',
-        overviewRulerLane: vscode.OverviewRulerLane.Left,
+        overviewRulerLane: OverviewRulerLane.Left,
         dark: {
             before: {
                 color: '#3BB26B',
@@ -61,10 +59,10 @@ export function notRanItName() {
 
 
 export function failingAssertionStyle(text: string) {
-    return vscode.window.createTextEditorDecorationType({
+    return window.createTextEditorDecorationType({
         isWholeLine: true,
         overviewRulerColor: 'red',
-        overviewRulerLane: vscode.OverviewRulerLane.Left,
+        overviewRulerLane: OverviewRulerLane.Left,
         light: {
             before: {
                 color: '#FF564B',

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,23 +1,23 @@
-import {workspace} from 'vscode';
-import {platform} from 'os';
-import {existsSync} from 'fs';
-import {normalize} from 'path';
+import { platform } from 'os';
+import { existsSync } from 'fs';
+import { normalize } from 'path';
+
+import { IPluginSettings } from './IPluginSettings';
 
 /**
  *  Handles getting the jest runner, handling the OS and project specific work too
  * 
  * @returns {string}
  */
-export function pathToJest(): string {
-  const jestSettings: any = workspace.getConfiguration('jest');
-  const path = normalize(jestSettings.pathToJest);
+export function pathToJest(pluginSettings: IPluginSettings) {
+  const path = normalize(pluginSettings.pathToJest);
 
-  const defaultPath = normalize('node_modules/.bin/jest'); 
+  const defaultPath = normalize('node_modules/.bin/jest');
   if (path === defaultPath) {
     const defaultCreateReactPath = 'node_modules/react-scripts/node_modules/.bin/jest';
     const defaultCreateReactPathWindows = 'node_modules/react-scripts/node_modules/.bin/jest.cmd';
     const createReactPath = (platform() === 'win32') ? defaultCreateReactPathWindows : defaultCreateReactPath;
-    const absolutePath = workspace.rootPath + '/' + createReactPath;
+    const absolutePath = pluginSettings.rootPath + '/' + createReactPath;
     if (!existsSync(path) && existsSync(absolutePath)) {
       // If it's the default, run the script instead
       return (platform() === 'win32') ? 'npm.cmd test --' : 'npm test --';
@@ -25,7 +25,7 @@ export function pathToJest(): string {
   }
 
   // For windows support, see https://github.com/orta/vscode-jest/issues/10
-  if (!path.includes('.cmd') && platform() === 'win32') { return path + '.cmd';  }
+  if (!path.includes('.cmd') && platform() === 'win32') { return path + '.cmd'; }
   return path;
 }
 
@@ -34,11 +34,10 @@ export function pathToJest(): string {
  *
  * @returns {string}
  */
-export function pathToConfig(): string {
-  const jestSettings: any = workspace.getConfiguration('jest');
+export function pathToConfig(pluginSettings: IPluginSettings) {
 
-  if (jestSettings.pathToConfig !== '') {
-    return normalize(jestSettings.pathToConfig);
+  if (pluginSettings.pathToConfig !== '') {
+    return normalize(pluginSettings.pathToConfig);
   }
 
   return '';

--- a/tests/JestExt.test.ts
+++ b/tests/JestExt.test.ts
@@ -21,7 +21,7 @@ describe('JestExt', () => {
             getConfig: callback => callback(),
             jestVersionMajor: 17
         }));
-        new JestExt(projectWorkspace, { appendLine: () => {} } as any);
+        new JestExt(projectWorkspace, { appendLine: () => {} } as any, {});
         expect(window.showErrorMessage).toBeCalledWith('This extension relies on Jest 18+ features, it will work, but the highlighting may not work correctly.');
     });
 
@@ -30,7 +30,7 @@ describe('JestExt', () => {
             getConfig: callback => callback(),
             jestVersionMajor: 18
         }));
-        new JestExt(projectWorkspace, { appendLine: () => {} } as any);
+        new JestExt(projectWorkspace, { appendLine: () => {} } as any, {});
         expect(window.showErrorMessage).not.toBeCalled();
     });
 });


### PR DESCRIPTION
currently we trigger decorators if you start with an active editor.  it doesn't wait for loading the testRegex and as a result when you first open the project with a test file active it doesn't show any decorators.

this change loads the decorators after settings are loaded