### PR TITLE
Apply prettier to the codebase

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,9 @@
     "typescript.tsdk": "./node_modules/typescript/lib", // we want to use the TS server from our node_modules folder to control its version
     "eslint.enable": false,
     "tslint.autoFixOnSave": true,
-    "jest.pathToConfig": "./jest.json"
+    "jest.pathToConfig": "./jest.json",
+    "prettier.semi": false,
+    "prettier.printWidth": 120,
+    "prettier.trailingComma": "es5",
+    "prettier.singleQuote": true
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master
 
+* Apply [prettier](https://github.com/prettier/prettier) to the codebase. - macklinu
+
 ### 2.2.1
 
 * Jest related depenendency bumps. Should improve the inline messages and crash less. - orta

--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -1,23 +1,18 @@
 const languages = {
-    createDiagnosticCollection: jest.fn(),
-};
+  createDiagnosticCollection: jest.fn(),
+}
 
-const StatusBarAlignment = {};
+const StatusBarAlignment = {}
 
 const window = {
-    createStatusBarItem: jest.fn(() => ({
-        show: jest.fn(),
-    })),
-    showErrorMessage: jest.fn(),
-};
+  createStatusBarItem: jest.fn(() => ({
+    show: jest.fn(),
+  })),
+  showErrorMessage: jest.fn(),
+}
 
 const workspace = {
-    getConfiguration: jest.fn(),
-};
+  getConfiguration: jest.fn(),
+}
 
-export {
-    languages,
-    StatusBarAlignment,
-    window,
-    workspace
-};
+export { languages, StatusBarAlignment, window, workspace }

--- a/package.json
+++ b/package.json
@@ -19,9 +19,7 @@
     "theme": "light",
     "color": "#ca461a"
   },
-  "categories": [
-    "Other"
-  ],
+  "categories": ["Other"],
   "activationEvents": [
     "workspaceContains:node_modules/.bin/jest",
     "workspaceContains:node_modules/react-scripts/node_modules/.bin/jest",
@@ -33,12 +31,7 @@
     "languages": [
       {
         "id": "jest-snapshot",
-        "extensions": [
-          ".js.snap",
-          ".jsx.snap",
-          ".ts.snap",
-          ".tsx.snap"
-        ]
+        "extensions": [".js.snap", ".jsx.snap", ".ts.snap", ".tsx.snap"]
       }
     ],
     "grammars": [
@@ -96,7 +89,12 @@
       }
     ]
   },
+  "lint-staged": {
+    "*.json": ["npm run prettier-write --", "git add"],
+    "*.ts": ["npm run prettier-write --", "git add"]
+  },
   "scripts": {
+    "precommit": "lint-staged",
     "ci": "yarn lint && yarn test",
     "clean-out": "rimraf ./out",
     "vscode:prepublish": "yarn clean-out && tsc -p ./tsconfig.publish.json",
@@ -104,15 +102,22 @@
     "lint": "node scripts/lint",
     "postinstall": "node ./node_modules/vscode/bin/install",
     "test": "jest --config jest.json",
-    "watch-test": "yarn test -- --watch"
+    "watch-test": "yarn test -- --watch",
+    "prettier": "prettier",
+    "prettier-write": "npm run prettier -- --parser typescript --no-semi --single-quote --trailing-comma es5 --write --print-width 120",
+    "prettier-project": "npm run prettier-write -- '?(__mocks__|src|tests)/**/*.ts'"
   },
   "devDependencies": {
     "@types/jest": "^19.2.3",
     "@types/node": "^6.0.40",
     "glob": "^7.1.1",
+    "husky": "^0.14.3",
     "jest": "^20.0.4",
+    "lint-staged": "^4.0.2",
+    "prettier": "^1.5.3",
     "rimraf": "^2.5.4",
     "tslint": "^4.5.1",
+    "tslint-config-prettier": "^1.3.0",
     "typescript": "^2.2.1",
     "vscode": "^1.1.0"
   },

--- a/src/IPluginSettings.ts
+++ b/src/IPluginSettings.ts
@@ -1,8 +1,8 @@
 export interface IPluginSettings {
-    autoEnable?: boolean;
-    enableInlineErrorMessages?: boolean;
-    enableSnapshotUpdateMessages?: boolean;
-    pathToJest?: string;
-    pathToConfig?: string;
-    rootPath?: string;
+  autoEnable?: boolean
+  enableInlineErrorMessages?: boolean
+  enableSnapshotUpdateMessages?: boolean
+  pathToJest?: string
+  pathToConfig?: string
+  rootPath?: string
 }

--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -1,386 +1,418 @@
-import * as vscode from 'vscode';
-import * as path from 'path';
+import * as vscode from 'vscode'
+import * as path from 'path'
 import {
-    Expect,
-    ItBlock,
-    Runner,
-    Settings,
-    ProjectWorkspace,
-    parse as babylonParse,
-    TestReconciler,
-    JestTotalResults,
-    IParseResults,
-} from 'jest-editor-support';
-import { parse as typescriptParse } from 'jest-test-typescript-parser';
+  Expect,
+  ItBlock,
+  Runner,
+  Settings,
+  ProjectWorkspace,
+  parse as babylonParse,
+  TestReconciler,
+  JestTotalResults,
+  IParseResults,
+} from 'jest-editor-support'
+import { parse as typescriptParse } from 'jest-test-typescript-parser'
 
-import * as decorations from './decorations';
-import { IPluginSettings } from './IPluginSettings';
-import * as status from './statusBar';
-import { TestReconciliationState } from './TestReconciliationState';
-import { pathToJestPackageJSON } from './helpers';
-import { readFileSync } from 'fs';
+import * as decorations from './decorations'
+import { IPluginSettings } from './IPluginSettings'
+import * as status from './statusBar'
+import { TestReconciliationState } from './TestReconciliationState'
+import { pathToJestPackageJSON } from './helpers'
+import { readFileSync } from 'fs'
 
 export class JestExt {
-    private workspace: ProjectWorkspace;
-    private jestProcess: Runner;
-    private jestSettings: Settings;
-    private reconciler: TestReconciler;
-    private pluginSettings: IPluginSettings;
+  private workspace: ProjectWorkspace
+  private jestProcess: Runner
+  private jestSettings: Settings
+  private reconciler: TestReconciler
+  private pluginSettings: IPluginSettings
 
-    // So you can read what's going on
-    private channel: vscode.OutputChannel;
+  // So you can read what's going on
+  private channel: vscode.OutputChannel
 
-    // The ability to show fails in the problems section
-    private failDiagnostics: vscode.DiagnosticCollection;
+  // The ability to show fails in the problems section
+  private failDiagnostics: vscode.DiagnosticCollection
 
-    private passingItStyle: vscode.TextEditorDecorationType;
-    private failingItStyle: vscode.TextEditorDecorationType;
-    private unknownItStyle: vscode.TextEditorDecorationType;
+  private passingItStyle: vscode.TextEditorDecorationType
+  private failingItStyle: vscode.TextEditorDecorationType
+  private unknownItStyle: vscode.TextEditorDecorationType
 
-    private parsingTestFile = false;
-    private parseResults: IParseResults = {
-        expects: [],
-        itBlocks: [],
-    };
+  private parsingTestFile = false
+  private parseResults: IParseResults = {
+    expects: [],
+    itBlocks: [],
+  }
 
-    // We have to keep track of our inline assert fails to remove later 
-    private failingAssertionDecorators: vscode.TextEditorDecorationType[];
+  // We have to keep track of our inline assert fails to remove later
+  private failingAssertionDecorators: vscode.TextEditorDecorationType[]
 
-    private clearOnNextInput: boolean;
+  private clearOnNextInput: boolean
 
-    constructor(workspace: ProjectWorkspace, outputChannel: vscode.OutputChannel, pluginSettings: IPluginSettings) {
-        this.workspace = workspace;
-        this.channel = outputChannel;
-        this.failingAssertionDecorators = [];
-        this.failDiagnostics = vscode.languages.createDiagnosticCollection('Jest');
-        this.clearOnNextInput = true;
-        this.reconciler = new TestReconciler();
-        this.jestSettings = new Settings(workspace);
-        this.pluginSettings = pluginSettings;
+  constructor(workspace: ProjectWorkspace, outputChannel: vscode.OutputChannel, pluginSettings: IPluginSettings) {
+    this.workspace = workspace
+    this.channel = outputChannel
+    this.failingAssertionDecorators = []
+    this.failDiagnostics = vscode.languages.createDiagnosticCollection('Jest')
+    this.clearOnNextInput = true
+    this.reconciler = new TestReconciler()
+    this.jestSettings = new Settings(workspace)
+    this.pluginSettings = pluginSettings
 
-        this.getSettings();
+    this.getSettings()
+  }
+
+  public startProcess() {
+    // The Runner is an event emitter that handles taking the Jest
+    // output and converting it into different types of data that
+    // we can handle here differently.
+    if (this.jestProcess) {
+      this.jestProcess.closeProcess()
+      delete this.jestProcess
     }
 
-    public startProcess() {
-        // The Runner is an event emitter that handles taking the Jest
-        // output and converting it into different types of data that
-        // we can handle here differently.
-        if (this.jestProcess) {
-            this.jestProcess.closeProcess();
-            delete this.jestProcess;
+    this.jestProcess = new Runner(this.workspace)
+
+    this.jestProcess
+      .on('debuggerComplete', () => {
+        this.channel.appendLine('Closed Jest')
+      })
+      .on('executableJSON', (data: JestTotalResults) => {
+        this.updateWithData(data)
+      })
+      .on('executableOutput', (output: string) => {
+        if (!output.includes('Watch Usage')) {
+          this.channel.appendLine(output)
+        }
+      })
+      .on('executableStdErr', (error: Buffer) => {
+        // The "tests are done" message comes through stdErr
+        // We want to use this as a marker that the console should
+        // be cleared, as the next input will be from a new test run.
+
+        if (this.clearOnNextInput) {
+          this.clearOnNextInput = false
+          this.parsingTestFile = false
+          this.testsHaveStartedRunning()
+        }
+        const message = error.toString()
+        // thanks Qix, http://stackoverflow.com/questions/25245716/remove-all-ansi-colors-styles-from-strings
+        const noANSI = message.replace(
+          /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g,
+          ''
+        )
+
+        if (noANSI.includes('snapshot test failed')) {
+          this.detectedSnapshotErrors()
         }
 
-        this.jestProcess = new Runner(this.workspace);
+        this.channel.appendLine(noANSI)
+      })
+      .on('nonTerminalError', (error: string) => {
+        this.channel.appendLine(`Received an error from Jest Runner: ${error.toString()}`)
+      })
+      .on('exception', result => {
+        this.channel.appendLine(`\nException raised: [${result.type}]: ${result.message}\n`)
+      })
+      .on('terminalError', (error: string) => {
+        this.channel.appendLine('\nException raised: ' + error)
+      })
 
-        this.jestProcess.on('debuggerComplete', () => {
-            this.channel.appendLine('Closed Jest');
-        }).on('executableJSON', (data: JestTotalResults) => {
-            this.updateWithData(data);
-        }).on('executableOutput', (output: string) => {
-            if (!output.includes('Watch Usage')) {
-                this.channel.appendLine(output);
-            }
-        }).on('executableStdErr', (error: Buffer) => {
-            // The "tests are done" message comes through stdErr
-            // We want to use this as a marker that the console should
-            // be cleared, as the next input will be from a new test run.
+    // The theme stuff
+    this.setupDecorators()
+    // The bottom bar thing
+    this.setupStatusBar()
+    // Go!
+    this.jestProcess.start()
+  }
 
-            if (this.clearOnNextInput) {
-                this.clearOnNextInput = false;
-                this.parsingTestFile = false;
-                this.testsHaveStartedRunning();
-            }
-            const message = error.toString();
-            // thanks Qix, http://stackoverflow.com/questions/25245716/remove-all-ansi-colors-styles-from-strings
-            const noANSI = message.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '');
+  public stopProcess() {
+    this.channel.appendLine('Closing Jest jest_runner.')
+    this.jestProcess.closeProcess()
+    delete this.jestProcess
+    status.stopped()
+  }
 
-            if (noANSI.includes('snapshot test failed')) {
-                this.detectedSnapshotErrors();
-            }
+  private getSettings() {
+    this.getJestVersion(jestVersionMajor => {
+      if (jestVersionMajor < 20) {
+        vscode.window.showErrorMessage(
+          'This extension relies on Jest 20+ features, it will continue to work, but some features may not work correctly.'
+        )
+      }
+      this.workspace.localJestMajorVersion = jestVersionMajor
 
-            this.channel.appendLine(noANSI);
-        }).on('nonTerminalError', (error: string) => {
-            this.channel.appendLine(`Received an error from Jest Runner: ${error.toString()}`);
-        }).on('exception', result => {
-            this.channel.appendLine(`\nException raised: [${result.type}]: ${result.message}\n`);
-        }).on('terminalError', (error: string) => {
-            this.channel.appendLine('\nException raised: ' + error);
-        });
+      // If we should start the process by default, do so
+      if (this.pluginSettings.autoEnable) {
+        this.startProcess()
+      } else {
+        this.channel.appendLine('Skipping initial Jest runner process start.')
+      }
+    })
 
-        // The theme stuff
-        this.setupDecorators();
-        // The bottom bar thing
-        this.setupStatusBar();
-        // Go!
-        this.jestProcess.start();
+    // Do nothing for the minute, the above ^ can come back once
+    // https://github.com/facebook/jest/pull/3592 is deployed
+    try {
+      this.jestSettings.getConfig(() => {})
+    } catch (error) {
+      console.log('[vscode-jest] Getting Jest config crashed, likely due to Jest version being below version 20.')
     }
+  }
 
-    public stopProcess() {
-        this.channel.appendLine('Closing Jest jest_runner.');
-        this.jestProcess.closeProcess();
-        delete this.jestProcess;
-        status.stopped();
+  private detectedSnapshotErrors() {
+    if (!this.pluginSettings.enableSnapshotUpdateMessages) {
+      return
     }
-
-    private getSettings() {
-        this.getJestVersion(jestVersionMajor => {
-            if (jestVersionMajor < 20) {
-                vscode.window.showErrorMessage('This extension relies on Jest 20+ features, it will continue to work, but some features may not work correctly.');
-            }
-            this.workspace.localJestMajorVersion = jestVersionMajor;
-
-            // If we should start the process by default, do so
-            if (this.pluginSettings.autoEnable) {
-                this.startProcess();
-            } else {
-                this.channel.appendLine('Skipping initial Jest runner process start.');
-            }
-        });
-
-        // Do nothing for the minute, the above ^ can come back once 
-        // https://github.com/facebook/jest/pull/3592 is deployed
-        try {
-            this.jestSettings.getConfig(() => {});  
-        } catch (error) {
-            console.log('[vscode-jest] Getting Jest config crashed, likely due to Jest version being below version 20.');
+    vscode.window
+      .showInformationMessage('Would you like to update your Snapshots?', { title: 'Replace them' })
+      .then(response => {
+        // No response == cancel
+        if (response) {
+          this.jestProcess.runJestWithUpdateForSnapshots(() => {
+            vscode.window.showInformationMessage('Updated Snapshots. It will show in your next test run.')
+          })
         }
+      })
+  }
+
+  public triggerUpdateDecorations(editor: vscode.TextEditor) {
+    if (!this.canUpdateDecorators(editor)) {
+      return
     }
 
-    private detectedSnapshotErrors() {
-        if (!this.pluginSettings.enableSnapshotUpdateMessages) { return; }
-        vscode.window.showInformationMessage('Would you like to update your Snapshots?', { title: 'Replace them' }).then((response) => {
-            // No response == cancel
-            if (response) {
-                this.jestProcess.runJestWithUpdateForSnapshots(() => {
-                    vscode.window.showInformationMessage('Updated Snapshots. It will show in your next test run.');
-                });
+    // OK - lets go
+    this.parsingTestFile = true
+
+    // This makes it cheaper later down the line
+    let successes: Array<ItBlock> = []
+    const fails: Array<ItBlock> = []
+    let unknowns: Array<ItBlock> = []
+
+    // Parse the current JS file
+    const path = editor.document.uri.fsPath
+    const isTypeScript = path.match(/.(ts|tsx)$/)
+    const parser = isTypeScript ? typescriptParse : babylonParse
+    this.parseResults = parser(editor.document.uri.fsPath)
+
+    // Use the parsers it blocks for references
+    const { itBlocks } = this.parseResults
+
+    // Loop through our it/test references, then ask the reconciler ( the thing
+    // that reads the JSON from Jest ) whether it has passed/failed/not ran.
+    const filePath = editor.document.uri.fsPath
+    const fileState = this.reconciler.stateForTestFile(filePath)
+    switch (fileState) {
+      // If the file failed, then it can contain passes, fails and unknowns
+      case TestReconciliationState.KnownFail:
+        itBlocks.forEach(it => {
+          const state = this.reconciler.stateForTestAssertion(filePath, it.name)
+          if (state !== null) {
+            switch (state.status) {
+              case TestReconciliationState.KnownSuccess:
+                successes.push(it)
+                break
+              case TestReconciliationState.KnownFail:
+                fails.push(it)
+                break
+              case TestReconciliationState.Unknown:
+                unknowns.push(it)
+                break
             }
-        });
+          } else {
+            unknowns.push(it)
+          }
+        })
+        break
+      // Test passed, all it's must be green
+      case TestReconciliationState.KnownSuccess:
+        successes = itBlocks
+        break
+
+      // We don't know, not ran probably
+      case TestReconciliationState.Unknown:
+        unknowns = itBlocks
+        break
     }
 
-    public triggerUpdateDecorations(editor: vscode.TextEditor) {
-        if (!this.canUpdateDecorators(editor)) { return; }
+    // Create a map for the states and styles to show inline.
+    // Note that this specifically is only for dots.
+    const styleMap = [
+      { data: successes, decorationType: this.passingItStyle, state: TestReconciliationState.KnownSuccess },
+      { data: fails, decorationType: this.failingItStyle, state: TestReconciliationState.KnownFail },
+      { data: unknowns, decorationType: this.unknownItStyle, state: TestReconciliationState.Unknown },
+    ]
+    styleMap.forEach(style => {
+      const decorators = this.generateDotsForItBlocks(style.data, style.state)
+      editor.setDecorations(style.decorationType, decorators)
+    })
 
-        // OK - lets go
-        this.parsingTestFile = true;
+    // Now we want to handle adding the error message after the failing assertion
+    // so first we need to clear all assertions, this is a bit of a shame as it can flash
+    // however, the API for a style in this case is not built to handle different inline texts
+    // as easily as it handles inline dots
 
-        // This makes it cheaper later down the line
-        let successes: Array<ItBlock> = [];
-        const fails: Array<ItBlock> = [];
-        let unknowns: Array<ItBlock> = [];
+    // Remove all of the existing line decorators
+    this.failingAssertionDecorators.forEach(element => {
+      editor.setDecorations(element, [])
+    })
+    this.failingAssertionDecorators = []
 
-        // Parse the current JS file
-        const path = editor.document.uri.fsPath;
-        const isTypeScript = path.match(/.(ts|tsx)$/);
-        const parser = isTypeScript ? typescriptParse : babylonParse;
-        this.parseResults = parser(editor.document.uri.fsPath);
-        
-        // Use the parsers it blocks for references
-        const { itBlocks } = this.parseResults;
+    // We've got JSON data back from Jest about a failing test run.
+    // We don't want to handle the decorators (inline dots/messages here)
+    // but we can handle creating "problems" for the workspace here.
 
-        // Loop through our it/test references, then ask the reconciler ( the thing 
-        // that reads the JSON from Jest ) whether it has passed/failed/not ran.
-        const filePath = editor.document.uri.fsPath;
-        const fileState = this.reconciler.stateForTestFile(filePath);
-        switch (fileState) {
-            // If the file failed, then it can contain passes, fails and unknowns
-            case TestReconciliationState.KnownFail:
-                itBlocks.forEach(it => {
-                    const state = this.reconciler.stateForTestAssertion(filePath, it.name);
-                    if (state !== null) {
-                        switch (state.status) {
-                            case TestReconciliationState.KnownSuccess:
-                                successes.push(it); break;
-                            case TestReconciliationState.KnownFail:
-                                fails.push(it); break;
-                            case TestReconciliationState.Unknown:
-                                unknowns.push(it); break;
-                        }
-                    } else {
-                        unknowns.push(it);
-                    }
-                });
-                break;
-            // Test passed, all it's must be green
-            case TestReconciliationState.KnownSuccess:
-                successes = itBlocks; break;
+    // For each failed file
+    this.reconciler.failedStatuses().forEach(fail => {
+      // Generate a uri, and pull out the failing it/tests
+      const uri = vscode.Uri.file(fail.file)
+      const asserts = fail.assertions.filter(a => a.status === TestReconciliationState.KnownFail)
 
-            // We don't know, not ran probably
-            case TestReconciliationState.Unknown:
-                unknowns = itBlocks; break;
-        };
+      // Support turning off the inline text
+      if (this.pluginSettings.enableInlineErrorMessages) {
+        asserts.forEach(assertion => {
+          const decorator = {
+            range: new vscode.Range(assertion.line - 1, 0, assertion.line - 1, 0),
+            hoverMessage: assertion.terseMessage,
+          }
+          // We have to make a new style for each unique message, this is
+          // why we have to remove off of them beforehand
+          const style = decorations.failingAssertionStyle(assertion.terseMessage)
+          this.failingAssertionDecorators.push(style)
+          editor.setDecorations(style, [decorator])
+        })
+      }
 
-        // Create a map for the states and styles to show inline.
-        // Note that this specifically is only for dots.
-        const styleMap = [
-            { data: successes, decorationType: this.passingItStyle, state: TestReconciliationState.KnownSuccess },
-            { data: fails, decorationType: this.failingItStyle, state: TestReconciliationState.KnownFail },
-            { data: unknowns, decorationType: this.unknownItStyle, state: TestReconciliationState.Unknown },
-        ];
-        styleMap.forEach(style => {
-            const decorators = this.generateDotsForItBlocks(style.data, style.state);
-            editor.setDecorations(style.decorationType, decorators);
-        });
+      // Loop through each individual fail and create an diagnostic
+      // to pass back to VS Code.
+      this.failDiagnostics.set(
+        uri,
+        asserts.map(assertion => {
+          const expect = this.expectAtLine(assertion.line)
+          const start = expect ? expect.start.column - 1 : 0
+          const daig = new vscode.Diagnostic(
+            new vscode.Range(assertion.line - 1, start, assertion.line - 1, start + 6),
+            assertion.terseMessage,
+            vscode.DiagnosticSeverity.Error
+          )
+          daig.source = 'Jest'
+          return daig
+        })
+      )
+    })
 
-        // Now we want to handle adding the error message after the failing assertion
-        // so first we need to clear all assertions, this is a bit of a shame as it can flash
-        // however, the API for a style in this case is not built to handle different inline texts 
-        // as easily as it handles inline dots
+    this.parsingTestFile = false
+  }
 
-        // Remove all of the existing line decorators
-        this.failingAssertionDecorators.forEach(element => {
-            editor.setDecorations(element, []);
-        });
-        this.failingAssertionDecorators = [];
-
-        // We've got JSON data back from Jest about a failing test run.
-        // We don't want to handle the decorators (inline dots/messages here)
-        // but we can handle creating "problems" for the workspace here.
-
-        // For each failed file
-        this.reconciler.failedStatuses().forEach(fail => {
-            // Generate a uri, and pull out the failing it/tests
-            const uri = vscode.Uri.file(fail.file);
-            const asserts = fail.assertions.filter(a => a.status === TestReconciliationState.KnownFail);
-
-            // Support turning off the inline text
-            if (this.pluginSettings.enableInlineErrorMessages) {
-                asserts.forEach((assertion) => {
-                    const decorator = {
-                        range: new vscode.Range(assertion.line - 1, 0, assertion.line - 1, 0),
-                        hoverMessage: assertion.terseMessage,
-                    };
-                    // We have to make a new style for each unique message, this is
-                    // why we have to remove off of them beforehand
-                    const style = decorations.failingAssertionStyle(assertion.terseMessage);
-                    this.failingAssertionDecorators.push(style);
-                    editor.setDecorations(style, [decorator]);
-                });
-            }
-
-            // Loop through each individual fail and create an diagnostic
-            // to pass back to VS Code.
-            this.failDiagnostics.set(uri, asserts.map(assertion => {
-                const expect = this.expectAtLine(assertion.line);
-                const start = expect ? expect.start.column - 1 : 0;
-                const daig = new vscode.Diagnostic(
-                    new vscode.Range(assertion.line - 1, start, assertion.line - 1, start + 6),
-                    assertion.terseMessage,
-                    vscode.DiagnosticSeverity.Error,
-                );
-                daig.source = 'Jest';
-                return daig;
-            }));
-        });
-
-        this.parsingTestFile = false;
+  private canUpdateDecorators(editor: vscode.TextEditor) {
+    const atEmptyScreen = !editor
+    if (atEmptyScreen) {
+      return false
     }
 
-    private canUpdateDecorators(editor: vscode.TextEditor) {
-        const atEmptyScreen = !editor;
-        if (atEmptyScreen) { return false; }
-
-        const inSettings = !editor.document;
-        if (inSettings) { return false; }
-
-        if (this.parsingTestFile) { return false; }
-
-        const isATestFile = this.wouldJestRunURI(editor.document.uri);
-        return isATestFile;
+    const inSettings = !editor.document
+    if (inSettings) {
+      return false
     }
 
-    private wouldJestRunURI(uri: vscode.Uri) {
-        const testRegex = new RegExp(this.jestSettings.settings.testRegex);
-        const root = this.pluginSettings.rootPath;
-        const filePath = uri.fsPath;
-        let relative = path.normalize(path.relative(root, filePath));
-        // replace windows path separator with normal slash
-        if (path.sep === '\\') {
-            relative = relative.replace(/\\/g, '/');
-        }
-
-        const matches = relative.match(testRegex);
-
-        return matches && matches.length > 0;
+    if (this.parsingTestFile) {
+      return false
     }
 
-    private setupStatusBar() {
-        if (this.pluginSettings.autoEnable) {
-            this.testsHaveStartedRunning();
-        } else {
-            status.initial();
-        }
+    const isATestFile = this.wouldJestRunURI(editor.document.uri)
+    return isATestFile
+  }
+
+  private wouldJestRunURI(uri: vscode.Uri) {
+    const testRegex = new RegExp(this.jestSettings.settings.testRegex)
+    const root = this.pluginSettings.rootPath
+    const filePath = uri.fsPath
+    let relative = path.normalize(path.relative(root, filePath))
+    // replace windows path separator with normal slash
+    if (path.sep === '\\') {
+      relative = relative.replace(/\\/g, '/')
     }
 
-    private setupDecorators() {
-        this.passingItStyle = decorations.passingItName();
-        this.failingItStyle = decorations.failingItName();
-        this.unknownItStyle = decorations.notRanItName();
+    const matches = relative.match(testRegex)
+
+    return matches && matches.length > 0
+  }
+
+  private setupStatusBar() {
+    if (this.pluginSettings.autoEnable) {
+      this.testsHaveStartedRunning()
+    } else {
+      status.initial()
+    }
+  }
+
+  private setupDecorators() {
+    this.passingItStyle = decorations.passingItName()
+    this.failingItStyle = decorations.failingItName()
+    this.unknownItStyle = decorations.notRanItName()
+  }
+
+  private testsHaveStartedRunning() {
+    this.channel.clear()
+    status.running()
+  }
+
+  private updateWithData(data: JestTotalResults) {
+    this.reconciler.updateFileWithJestStatus(data)
+    this.failDiagnostics.clear()
+
+    if (data.success) {
+      status.success()
+    } else {
+      status.failed()
     }
 
-    private testsHaveStartedRunning() {
-        this.channel.clear();
-        status.running();
+    this.triggerUpdateDecorations(vscode.window.activeTextEditor)
+    this.clearOnNextInput = true
+  }
+
+  private generateDotsForItBlocks(blocks: ItBlock[], state: TestReconciliationState): vscode.DecorationOptions[] {
+    const nameForState = (_name: string, state: TestReconciliationState): string => {
+      switch (state) {
+        case TestReconciliationState.KnownSuccess:
+          return 'Passed'
+        case TestReconciliationState.KnownFail:
+          return 'Failed'
+        case TestReconciliationState.Unknown:
+          return 'Test has not run yet, due to Jest only running tests related to changes.'
+      }
     }
+    return blocks.map(it => {
+      return {
+        // VS Code is indexed starting at 0
+        // jest-editor-support is indexed starting at 1
+        range: new vscode.Range(it.start.line - 1, it.start.column - 1, it.start.line - 1, it.start.column + 1),
+        hoverMessage: nameForState(it.name, state),
+      }
+    })
+  }
 
-    private updateWithData(data: JestTotalResults) {
-        this.reconciler.updateFileWithJestStatus(data);
-        this.failDiagnostics.clear();
+  // When we want to show an inline assertion, the only bit of
+  // data to work with is the line number from the stack trace.
+  // So we need to be able to go from that to the real
+  // expect data.
+  private expectAtLine(line: number): null | Expect {
+    return this.parseResults.expects.find(e => e.start.line === line)
+  }
 
-        if (data.success) {
-            status.success();
-        } else {
-            status.failed();
-        }
+  public deactivate() {
+    this.jestProcess.closeProcess()
+  }
 
-        this.triggerUpdateDecorations(vscode.window.activeTextEditor);
-        this.clearOnNextInput = true;
+  private getJestVersion(version: (v: number) => void) {
+    const packageJSON = pathToJestPackageJSON(this.pluginSettings)
+    if (packageJSON) {
+      const contents = readFileSync(packageJSON, 'utf8')
+      const packageMetadata = JSON.parse(contents)
+      if (packageMetadata['version']) {
+        version(parseInt(packageMetadata['version']))
+        return
+      }
     }
-
-    private generateDotsForItBlocks(blocks: ItBlock[], state: TestReconciliationState): vscode.DecorationOptions[] {
-        const nameForState = (_name: string, state: TestReconciliationState): string => {
-            switch (state) {
-                case TestReconciliationState.KnownSuccess:
-                    return 'Passed';
-                case TestReconciliationState.KnownFail:
-                    return 'Failed';
-                case TestReconciliationState.Unknown:
-                    return 'Test has not run yet, due to Jest only running tests related to changes.';
-            }
-        };
-        return blocks.map(it => {
-            return {
-                // VS Code is indexed starting at 0
-                // jest-editor-support is indexed starting at 1
-                range: new vscode.Range(it.start.line - 1, it.start.column - 1, it.start.line - 1, it.start.column + 1),
-                hoverMessage: nameForState(it.name, state),
-            };
-        });
-    }
-
-    // When we want to show an inline assertion, the only bit of
-    // data to work with is the line number from the stack trace.
-    // So we need to be able to go from that to the real
-    // expect data.
-    private expectAtLine(line: number): null | Expect {
-        return this.parseResults.expects.find((e) => e.start.line === line);
-    }
-
-    public deactivate() {
-        this.jestProcess.closeProcess();
-    }
-
-    private getJestVersion(version: (v:number) => void) {
-        const packageJSON = pathToJestPackageJSON(this.pluginSettings);
-        if (packageJSON) {
-            const contents = readFileSync(packageJSON, 'utf8');
-            const packageMetadata = JSON.parse(contents);
-            if (packageMetadata['version']) {
-                version(parseInt(packageMetadata['version']));
-                return;
-            }
-        }
-        // Fallback to last pre-20 release
-        version(18);
-    }
+    // Fallback to last pre-20 release
+    version(18)
+  }
 }

--- a/src/TestReconciliationState.ts
+++ b/src/TestReconciliationState.ts
@@ -1,8 +1,6 @@
-export type TestReconciliationState = 'Unknown' |
-    'KnownSuccess' |
-    'KnownFail';
+export type TestReconciliationState = 'Unknown' | 'KnownSuccess' | 'KnownFail'
 export const TestReconciliationState = {
-    Unknown: 'Unknown' as TestReconciliationState,
-    KnownSuccess: 'KnownSuccess' as TestReconciliationState,
-    KnownFail: 'KnownFail' as TestReconciliationState,
-};
+  Unknown: 'Unknown' as TestReconciliationState,
+  KnownSuccess: 'KnownSuccess' as TestReconciliationState,
+  KnownFail: 'KnownFail' as TestReconciliationState,
+}

--- a/src/appGlobals.ts
+++ b/src/appGlobals.ts
@@ -1,1 +1,1 @@
-export const extensionName = 'io.orta.jest';
+export const extensionName = 'io.orta.jest'

--- a/src/decorations.ts
+++ b/src/decorations.ts
@@ -1,80 +1,79 @@
-import { window, OverviewRulerLane } from 'vscode';
+import { window, OverviewRulerLane } from 'vscode'
 
 export function failingItName() {
-    return window.createTextEditorDecorationType({
-        overviewRulerColor: 'red',
-        overviewRulerLane: OverviewRulerLane.Left,
-        light: {
-            before: {
-                color: '#FF564B',
-                contentText: '●',
-            },
-        },
-        dark: {
-            before: {
-                color: '#AD322D',
-                contentText: '●',
-            },
-        },
-    });
+  return window.createTextEditorDecorationType({
+    overviewRulerColor: 'red',
+    overviewRulerLane: OverviewRulerLane.Left,
+    light: {
+      before: {
+        color: '#FF564B',
+        contentText: '●',
+      },
+    },
+    dark: {
+      before: {
+        color: '#AD322D',
+        contentText: '●',
+      },
+    },
+  })
 }
 
 export function passingItName() {
-    return window.createTextEditorDecorationType({
-        overviewRulerColor: 'green',
-        overviewRulerLane: OverviewRulerLane.Left,
-        light: {
-            before: {
-                color: '#3BB26B',
-                contentText: '●', 
-            },
-        },
-        dark: {
-            before: {
-                color: '#2F8F51',
-                contentText: '●',
-            },
-        },
-    });
+  return window.createTextEditorDecorationType({
+    overviewRulerColor: 'green',
+    overviewRulerLane: OverviewRulerLane.Left,
+    light: {
+      before: {
+        color: '#3BB26B',
+        contentText: '●',
+      },
+    },
+    dark: {
+      before: {
+        color: '#2F8F51',
+        contentText: '●',
+      },
+    },
+  })
 }
 
 export function notRanItName() {
-    return window.createTextEditorDecorationType({
-        overviewRulerColor: 'darkgrey',
-        overviewRulerLane: OverviewRulerLane.Left,
-        dark: {
-            before: {
-                color: '#3BB26B',
-                contentText: '○',
-            },    
-        },
-        light: {
-            before: {
-                color: '#2F8F51',
-                contentText: '○',
-            },    
-        },
-    });
+  return window.createTextEditorDecorationType({
+    overviewRulerColor: 'darkgrey',
+    overviewRulerLane: OverviewRulerLane.Left,
+    dark: {
+      before: {
+        color: '#3BB26B',
+        contentText: '○',
+      },
+    },
+    light: {
+      before: {
+        color: '#2F8F51',
+        contentText: '○',
+      },
+    },
+  })
 }
 
-
 export function failingAssertionStyle(text: string) {
-    return window.createTextEditorDecorationType({
-        isWholeLine: true,
-        overviewRulerColor: 'red',
-        overviewRulerLane: OverviewRulerLane.Left,
-        light: {
-            before: {
-                color: '#FF564B',
-            },
-        },
-        dark: {
-            before: {
-                color: '#AD322D',
-            },
-        },
-        after: {
-            contentText: ' // ' + text,
-        },
-    });
+  return window.createTextEditorDecorationType({
+    isWholeLine: true,
+    overviewRulerColor: 'red',
+    overviewRulerLane: OverviewRulerLane.Left,
+    light: {
+      before: {
+        color: '#FF564B',
+      },
+    },
+    dark: {
+      before: {
+        color: '#AD322D',
+      },
+    },
+    after: {
+      contentText: ' // ' + text,
+    },
+  })
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,58 +1,52 @@
-import * as vscode from 'vscode';
-import { ProjectWorkspace } from 'jest-editor-support';
+import * as vscode from 'vscode'
+import { ProjectWorkspace } from 'jest-editor-support'
 
-import { extensionName } from './appGlobals';
-import { pathToJest, pathToConfig } from './helpers';
-import { JestExt } from './JestExt';
-import { IPluginSettings } from './IPluginSettings'; 
-import { registerStatusBar } from './statusBar';
-import { registerFileChangeWatchers } from './fileChangeWatchers';
+import { extensionName } from './appGlobals'
+import { pathToJest, pathToConfig } from './helpers'
+import { JestExt } from './JestExt'
+import { IPluginSettings } from './IPluginSettings'
+import { registerStatusBar } from './statusBar'
+import { registerFileChangeWatchers } from './fileChangeWatchers'
 
-let extensionInstance: JestExt;
+let extensionInstance: JestExt
 
 export function activate(context: vscode.ExtensionContext) {
-    // To make us VS Code agnostic outside of this file
-    const workspaceConfig = vscode.workspace.getConfiguration('jest');
-    const pluginSettings: IPluginSettings = {
-        autoEnable: workspaceConfig.get<boolean>('autoEnable'),
-        pathToConfig: workspaceConfig.get<string>('pathToConfig'),
-        pathToJest: workspaceConfig.get<string>('pathToJest'),
-        enableInlineErrorMessages: workspaceConfig.get<boolean>('enableInlineErrorMessages'),
-        enableSnapshotUpdateMessages: workspaceConfig.get<boolean>('enableSnapshotUpdateMessages'),
-        rootPath: vscode.workspace.rootPath,
-    };
+  // To make us VS Code agnostic outside of this file
+  const workspaceConfig = vscode.workspace.getConfiguration('jest')
+  const pluginSettings: IPluginSettings = {
+    autoEnable: workspaceConfig.get<boolean>('autoEnable'),
+    pathToConfig: workspaceConfig.get<string>('pathToConfig'),
+    pathToJest: workspaceConfig.get<string>('pathToJest'),
+    enableInlineErrorMessages: workspaceConfig.get<boolean>('enableInlineErrorMessages'),
+    enableSnapshotUpdateMessages: workspaceConfig.get<boolean>('enableSnapshotUpdateMessages'),
+    rootPath: vscode.workspace.rootPath,
+  }
 
-    const jestPath = pathToJest(pluginSettings);
-    const configPath = pathToConfig(pluginSettings); 
-    const currentJestVersion = 20;
-    const workspace = new ProjectWorkspace(pluginSettings.rootPath, jestPath, configPath, currentJestVersion);
+  const jestPath = pathToJest(pluginSettings)
+  const configPath = pathToConfig(pluginSettings)
+  const currentJestVersion = 20
+  const workspace = new ProjectWorkspace(pluginSettings.rootPath, jestPath, configPath, currentJestVersion)
 
-    // Create our own console
-    const channel = vscode.window.createOutputChannel('Jest');
+  // Create our own console
+  const channel = vscode.window.createOutputChannel('Jest')
 
-    // We need a singleton to represent the extension
-    extensionInstance = new JestExt(workspace, channel, pluginSettings);
+  // We need a singleton to represent the extension
+  extensionInstance = new JestExt(workspace, channel, pluginSettings)
 
-    context.subscriptions.push(
-        registerStatusBar(channel),
-        vscode.commands.registerTextEditorCommand(
-            `${extensionName}.start`,
-            () => {
-                vscode.window.showInformationMessage('Started Jest, press escape to hide this message.');
-                extensionInstance.startProcess();
-            },
-        ),
-        vscode.commands.registerTextEditorCommand(
-            `${extensionName}.stop`,
-            () => extensionInstance.stopProcess(),
-        ),
-        vscode.commands.registerTextEditorCommand('io.orta.jest.show-channel', ()=> {
-            channel.show();
-        }),
-        ...registerFileChangeWatchers(extensionInstance),
-    );
+  context.subscriptions.push(
+    registerStatusBar(channel),
+    vscode.commands.registerTextEditorCommand(`${extensionName}.start`, () => {
+      vscode.window.showInformationMessage('Started Jest, press escape to hide this message.')
+      extensionInstance.startProcess()
+    }),
+    vscode.commands.registerTextEditorCommand(`${extensionName}.stop`, () => extensionInstance.stopProcess()),
+    vscode.commands.registerTextEditorCommand('io.orta.jest.show-channel', () => {
+      channel.show()
+    }),
+    ...registerFileChangeWatchers(extensionInstance)
+  )
 }
 
 export function deactivate() {
-    extensionInstance.deactivate();
+  extensionInstance.deactivate()
 }

--- a/src/fileChangeWatchers.ts
+++ b/src/fileChangeWatchers.ts
@@ -1,26 +1,26 @@
-import * as vscode from 'vscode';
+import * as vscode from 'vscode'
 
-import { JestExt } from './JestExt';
+import { JestExt } from './JestExt'
 
 export function registerFileChangeWatchers(jestExt: JestExt) {
-	let activeEditor = vscode.window.activeTextEditor;
+  let activeEditor = vscode.window.activeTextEditor
 
-	return [
-		vscode.window.onDidChangeActiveTextEditor(editor => {
-			activeEditor = editor;
-			jestExt.triggerUpdateDecorations(activeEditor);
-		}),
+  return [
+    vscode.window.onDidChangeActiveTextEditor(editor => {
+      activeEditor = editor
+      jestExt.triggerUpdateDecorations(activeEditor)
+    }),
 
-		vscode.workspace.onDidSaveTextDocument(document => {
-			if (document) {
-				jestExt.triggerUpdateDecorations(activeEditor);
-			}
-		}),
+    vscode.workspace.onDidSaveTextDocument(document => {
+      if (document) {
+        jestExt.triggerUpdateDecorations(activeEditor)
+      }
+    }),
 
-		vscode.workspace.onDidChangeTextDocument(({ document }) => {
-			if (activeEditor && document === activeEditor.document) {
-				jestExt.triggerUpdateDecorations(activeEditor);
-			}
-		}),
-	];
+    vscode.workspace.onDidChangeTextDocument(({ document }) => {
+      if (activeEditor && document === activeEditor.document) {
+        jestExt.triggerUpdateDecorations(activeEditor)
+      }
+    }),
+  ]
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,8 +1,8 @@
-import { platform } from 'os';
-import { existsSync } from 'fs';
-import { normalize, join } from 'path';
+import { platform } from 'os'
+import { existsSync } from 'fs'
+import { normalize, join } from 'path'
 
-import { IPluginSettings } from './IPluginSettings';
+import { IPluginSettings } from './IPluginSettings'
 
 /**
  *  Handles getting the jest runner, handling the OS and project specific work too
@@ -10,25 +10,27 @@ import { IPluginSettings } from './IPluginSettings';
  * @returns {string}
  */
 export function pathToJest(pluginSettings: IPluginSettings) {
-  const path = normalize(pluginSettings.pathToJest);
+  const path = normalize(pluginSettings.pathToJest)
 
-  const defaultPath = normalize('node_modules/.bin/jest');
+  const defaultPath = normalize('node_modules/.bin/jest')
   if (path === defaultPath) {
-    const defaultCreateReactPath = 'node_modules/react-scripts/node_modules/.bin/jest';
-    const defaultCreateReactPathWindows = 'node_modules/react-scripts/node_modules/.bin/jest.cmd';
-    const createReactPath = (platform() === 'win32') ? defaultCreateReactPathWindows : defaultCreateReactPath;
-    const absolutePath = join(pluginSettings.rootPath, createReactPath);
+    const defaultCreateReactPath = 'node_modules/react-scripts/node_modules/.bin/jest'
+    const defaultCreateReactPathWindows = 'node_modules/react-scripts/node_modules/.bin/jest.cmd'
+    const createReactPath = platform() === 'win32' ? defaultCreateReactPathWindows : defaultCreateReactPath
+    const absolutePath = join(pluginSettings.rootPath, createReactPath)
 
-    const craExists = existsSync(absolutePath);
+    const craExists = existsSync(absolutePath)
     if (craExists) {
       // If it's the default, run the script instead
-      return (platform() === 'win32') ? 'npm.cmd test --' : 'npm test --';
+      return platform() === 'win32' ? 'npm.cmd test --' : 'npm test --'
     }
   }
 
   // For windows support, see https://github.com/orta/vscode-jest/issues/10
-  if (!path.includes('.cmd') && platform() === 'win32') { return path + '.cmd'; }
-  return path;
+  if (!path.includes('.cmd') && platform() === 'win32') {
+    return path + '.cmd'
+  }
+  return path
 }
 
 /**
@@ -37,24 +39,23 @@ export function pathToJest(pluginSettings: IPluginSettings) {
  * @returns {string}
  */
 export function pathToConfig(pluginSettings: IPluginSettings) {
-
   if (pluginSettings.pathToConfig !== '') {
-    return normalize(pluginSettings.pathToConfig);
+    return normalize(pluginSettings.pathToConfig)
   }
 
-  return '';
-} 
+  return ''
+}
 
 export function pathToJestPackageJSON(pluginSettings: IPluginSettings): string | null {
-  const defaultPath = normalize('node_modules/jest/package.json');
-  const craPath = normalize('node_modules/react-scripts/node_modules/jest/package.json');
+  const defaultPath = normalize('node_modules/jest/package.json')
+  const craPath = normalize('node_modules/react-scripts/node_modules/jest/package.json')
 
-  const paths = [defaultPath, craPath];
+  const paths = [defaultPath, craPath]
   for (const i in paths) {
-    const absolutePath = join(pluginSettings.rootPath, paths[i]);
-    if (existsSync(absolutePath)) { 
-      return absolutePath; 
-    } 
+    const absolutePath = join(pluginSettings.rootPath, paths[i])
+    if (existsSync(absolutePath)) {
+      return absolutePath
+    }
   }
-  return null;
+  return null
 }

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -1,49 +1,46 @@
-import { window, StatusBarAlignment, commands, OutputChannel } from 'vscode';
-import * as elegantSpinner from 'elegant-spinner';
+import { window, StatusBarAlignment, commands, OutputChannel } from 'vscode'
+import * as elegantSpinner from 'elegant-spinner'
 
-import { extensionName } from './appGlobals';
+import { extensionName } from './appGlobals'
 
 // The bottom status bar
-const statusBarCommand = `${extensionName}.show-output`;
-const statusBarItem = window.createStatusBarItem(StatusBarAlignment.Left);
-statusBarItem.show();
-statusBarItem.command = statusBarCommand;
-const statusKey = 'Jest:';
-const frame = elegantSpinner();
-let statusBarSpinner: any;
+const statusBarCommand = `${extensionName}.show-output`
+const statusBarItem = window.createStatusBarItem(StatusBarAlignment.Left)
+statusBarItem.show()
+statusBarItem.command = statusBarCommand
+const statusKey = 'Jest:'
+const frame = elegantSpinner()
+let statusBarSpinner: any
 
 export function registerStatusBar(channel: OutputChannel) {
-    return commands.registerCommand(
-        statusBarCommand,
-        () => channel.show(),
-    );
+  return commands.registerCommand(statusBarCommand, () => channel.show())
 }
 
 export function initial() {
-    updateStatus('...');
+  updateStatus('...')
 }
 
 export function running() {
-    clearInterval(statusBarSpinner);
-    statusBarSpinner = setInterval(() => {
-        statusBarItem.text = `${statusKey} ${frame()}`;
-    }, 100);
+  clearInterval(statusBarSpinner)
+  statusBarSpinner = setInterval(() => {
+    statusBarItem.text = `${statusKey} ${frame()}`
+  }, 100)
 }
 
 export function success() {
-    updateStatus('$(check)');
+  updateStatus('$(check)')
 }
 
 export function failed() {
-    updateStatus('$(alert)');
+  updateStatus('$(alert)')
 }
 
 export function stopped() {
-    updateStatus('stopped');
-    setTimeout(() => initial(), 2000);
+  updateStatus('stopped')
+  setTimeout(() => initial(), 2000)
 }
 
 function updateStatus(message: string) {
-    clearInterval(statusBarSpinner);
-    statusBarItem.text = `${statusKey} ${message}`;
+  clearInterval(statusBarSpinner)
+  statusBarItem.text = `${statusKey} ${message}`
 }

--- a/tests/JestExt.test.ts
+++ b/tests/JestExt.test.ts
@@ -1,67 +1,65 @@
-jest.unmock('../src/JestExt');
+jest.unmock('../src/JestExt')
 
-import { JestExt } from '../src/JestExt';
-import { ProjectWorkspace, Settings, Runner } from 'jest-editor-support';
-import { window, workspace } from 'vscode';
-
+import { JestExt } from '../src/JestExt'
+import { ProjectWorkspace, Settings, Runner } from 'jest-editor-support'
+import { window, workspace } from 'vscode'
 
 describe('JestExt', () => {
-    const mockSettings = Settings as any as jest.Mock<any>;
-    const mockRunner = Runner as any as jest.Mock<any>;
-    const getConfiguration = workspace.getConfiguration as jest.Mock<any>;
-    let projectWorkspace: ProjectWorkspace;
-    const channelStub = { appendLine: () => { } } as any;
+  const mockSettings = (Settings as any) as jest.Mock<any>
+  const mockRunner = (Runner as any) as jest.Mock<any>
+  const getConfiguration = workspace.getConfiguration as jest.Mock<any>
+  let projectWorkspace: ProjectWorkspace
+  const channelStub = { appendLine: () => {} } as any
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+
+    projectWorkspace = new ProjectWorkspace(null, null, null, null)
+    getConfiguration.mockReturnValue({})
+  })
+
+  it('should show error message if jest version i < 18', () => {
+    mockSettings.mockImplementation(() => ({
+      getConfig: callback => callback(),
+      jestVersionMajor: 17,
+    }))
+    new JestExt(projectWorkspace, channelStub, {})
+    expect(window.showErrorMessage.mock.calls).toMatchSnapshot()
+  })
+
+  it.skip('should not show error message if jest version is 20', () => {
+    mockSettings.mockImplementation(() => ({
+      getConfig: callback => callback(),
+      jestVersionMajor: 20,
+    }))
+    new JestExt(projectWorkspace, channelStub, {})
+    expect(window.showErrorMessage).not.toBeCalled()
+  })
+
+  describe('after starting the process', () => {
+    const closeProcess = jest.fn()
+    let extension: JestExt
 
     beforeEach(() => {
-        jest.resetAllMocks();
+      const eventEmitter = {
+        on: jest.fn(() => eventEmitter),
+        start: jest.fn(),
+        closeProcess,
+      }
+      mockRunner.mockImplementation(() => eventEmitter)
+      extension = new JestExt(projectWorkspace, channelStub, {})
+      extension.startProcess()
+    })
 
-        projectWorkspace = new ProjectWorkspace(null, null, null, null);
-        getConfiguration.mockReturnValue({});
-    });
+    it('should not attempt to closeProcess again after stopping and starting', () => {
+      extension.stopProcess()
+      extension.startProcess()
+      expect(closeProcess).toHaveBeenCalledTimes(1)
+    })
 
-    it('should show error message if jest version i < 18', () => {
-        mockSettings.mockImplementation(() => ({
-            getConfig: callback => callback(),
-            jestVersionMajor: 17,
-        }));
-        new JestExt(projectWorkspace, channelStub, {});
-        expect(window.showErrorMessage.mock.calls).toMatchSnapshot();
-    });
-
-    it.skip('should not show error message if jest version is 20', () => {
-        mockSettings.mockImplementation(() => ({
-            getConfig: callback => callback(),
-            jestVersionMajor: 20,
-        }));
-        new JestExt(projectWorkspace, channelStub, {});
-        expect(window.showErrorMessage).not.toBeCalled();
-    });
-
-    describe('after starting the process', () => {
-        const closeProcess = jest.fn();
-        let extension: JestExt;
-
-        beforeEach(() => {
-            const eventEmitter = {
-                on: jest.fn(() => eventEmitter),
-                start: jest.fn(),
-                closeProcess,
-            };
-            mockRunner.mockImplementation(() => eventEmitter);
-            extension = new JestExt(projectWorkspace, channelStub, {});
-            extension.startProcess();
-        });
-        
-
-        it('should not attempt to closeProcess again after stopping and starting', () => {
-            extension.stopProcess();
-            extension.startProcess();
-            expect(closeProcess).toHaveBeenCalledTimes(1);
-        });
-
-        it('should closeProcess when starting again', () => {
-            extension.startProcess();
-            expect(closeProcess).toHaveBeenCalledTimes(1);
-        });
-    });
-});
+    it('should closeProcess when starting again', () => {
+      extension.startProcess()
+      expect(closeProcess).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/tslint.json
+++ b/tslint.json
@@ -1,25 +1,13 @@
 {
-	"rules": {
-		"class-name": true,
-		"curly": true,
-		"eofline": true,
-		"no-duplicate-variable": true,
-		"no-unused-expression": true,
-		"no-var-keyword": true,
-		"prefer-const": true,
-		"quotemark": [
-			true,
-			"single"
-		],
-		"semicolon": [
-			"never"
-		],
-		"triple-equals": true,
-		"trailing-comma": [
-			true,
-			{
-				"multiline": "always"
-			}
-		]
-	}
+  "extends": ["tslint-config-prettier"],
+  "rules": {
+    "class-name": true,
+    "curly": true,
+    "eofline": true,
+    "no-duplicate-variable": true,
+    "no-unused-expression": true,
+    "no-var-keyword": true,
+    "prefer-const": true,
+    "triple-equals": true
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,7 +42,7 @@ ansi-align@^1.1.0:
   dependencies:
     string-width "^1.0.1"
 
-ansi-escapes@^1.4.0:
+ansi-escapes@^1.0.0, ansi-escapes@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
 
@@ -70,6 +70,10 @@ anymatch@^1.3.0:
   dependencies:
     arrify "^1.0.0"
     micromatch "^2.1.5"
+
+app-root-path@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.0.1.tgz#cd62dcf8e4fd5a417efc664d2e5b10653c651b46"
 
 append-transform@^0.4.0:
   version "0.4.0"
@@ -447,6 +451,23 @@ cli-boxes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
 
+cli-cursor@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
+  dependencies:
+    restore-cursor "^1.0.1"
+
+cli-spinners@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-0.1.2.tgz#bb764d88e185fb9e1e6a2a1f19772318f605e31c"
+
+cli-truncate@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
+  dependencies:
+    slice-ansi "0.0.4"
+    string-width "^1.0.1"
+
 cliui@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
@@ -552,6 +573,19 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+cosmiconfig@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-1.1.0.tgz#0dea0f9804efdfb929fbb1b188e25553ea053d37"
+  dependencies:
+    graceful-fs "^4.1.2"
+    js-yaml "^3.4.3"
+    minimist "^1.2.0"
+    object-assign "^4.0.1"
+    os-homedir "^1.0.1"
+    parse-json "^2.2.0"
+    pinkie-promise "^2.0.0"
+    require-from-string "^1.1.0"
+
 create-error-class@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
@@ -564,6 +598,14 @@ cross-spawn-async@^2.1.1:
   dependencies:
     lru-cache "^4.0.0"
     which "^1.2.8"
+
+cross-spawn@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
 
 cryptiles@2.x.x:
   version "2.0.5"
@@ -596,6 +638,10 @@ dashdash@^1.12.0:
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   dependencies:
     assert-plus "^1.0.0"
+
+date-fns@^1.27.2:
+  version "1.28.5"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.28.5.tgz#257cfc45d322df45ef5658665967ee841cd73faf"
 
 dateformat@^1.0.11:
   version "1.0.12"
@@ -723,7 +769,7 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
-escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -745,6 +791,10 @@ esprima@^2.7.1:
 esprima@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
+
+esprima@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
 
 estraverse@^1.9.1:
   version "1.9.3"
@@ -782,6 +832,22 @@ execa@^0.4.0:
     object-assign "^4.0.1"
     path-key "^1.0.0"
     strip-eof "^1.0.0"
+
+execa@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
+exit-hook@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
 
 expand-brackets@^0.1.4:
   version "0.1.5"
@@ -843,6 +909,13 @@ fd-slicer@~1.0.1:
   resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
   dependencies:
     pend "~1.2.0"
+
+figures@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    object-assign "^4.1.0"
 
 filename-regex@^2.0.0:
   version "2.0.0"
@@ -1261,6 +1334,14 @@ http-signature@~1.1.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+husky@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
+  dependencies:
+    is-ci "^1.0.10"
+    normalize-path "^1.0.0"
+    strip-indent "^2.0.0"
+
 iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
@@ -1274,6 +1355,10 @@ indent-string@^2.1.0:
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
   dependencies:
     repeating "^2.0.0"
+
+indent-string@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -1401,6 +1486,10 @@ is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
 
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+
 is-property@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
@@ -1444,6 +1533,10 @@ isarray@1.0.0, isarray@~1.0.0:
 isexe@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-1.1.2.tgz#36f3e22e60750920f5e7241a476a8c6a42275ad0"
+
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
 isobject@^2.0.0:
   version "2.1.0"
@@ -1752,6 +1845,13 @@ js-tokens@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-2.0.0.tgz#79903f5563ee778cc1162e6dcf1a0027c97f9cb5"
 
+js-yaml@^3.4.3:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.9.0.tgz#4ffbbf25c2ac963b8299dc74da7e3740de1c18ce"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 js-yaml@^3.7.0:
   version "3.8.4"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.4.tgz#520b4564f86573ba96662af85a8cafa7b4b5a6f6"
@@ -1872,6 +1972,67 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lint-staged@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-4.0.2.tgz#8e83e11e9e1656c09b6117f6db0d55fd4960a1c0"
+  dependencies:
+    app-root-path "^2.0.0"
+    cosmiconfig "^1.1.0"
+    execa "^0.7.0"
+    listr "^0.12.0"
+    lodash.chunk "^4.2.0"
+    minimatch "^3.0.0"
+    npm-which "^3.0.1"
+    p-map "^1.1.1"
+    staged-git-files "0.0.4"
+
+listr-silent-renderer@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
+
+listr-update-renderer@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz#ca80e1779b4e70266807e8eed1ad6abe398550f9"
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    elegant-spinner "^1.0.1"
+    figures "^1.7.0"
+    indent-string "^3.0.0"
+    log-symbols "^1.0.2"
+    log-update "^1.0.2"
+    strip-ansi "^3.0.1"
+
+listr-verbose-renderer@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/listr-verbose-renderer/-/listr-verbose-renderer-0.4.0.tgz#44dc01bb0c34a03c572154d4d08cde9b1dc5620f"
+  dependencies:
+    chalk "^1.1.3"
+    cli-cursor "^1.0.2"
+    date-fns "^1.27.2"
+    figures "^1.7.0"
+
+listr@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/listr/-/listr-0.12.0.tgz#6bce2c0f5603fa49580ea17cd6a00cc0e5fa451a"
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    figures "^1.7.0"
+    indent-string "^2.1.0"
+    is-promise "^2.1.0"
+    is-stream "^1.1.0"
+    listr-silent-renderer "^1.1.1"
+    listr-update-renderer "^0.2.0"
+    listr-verbose-renderer "^0.4.0"
+    log-symbols "^1.0.2"
+    log-update "^1.0.2"
+    ora "^0.2.3"
+    p-map "^1.1.1"
+    rxjs "^5.0.0-beta.11"
+    stream-to-observable "^0.1.0"
+    strip-ansi "^3.0.1"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -1936,6 +2097,10 @@ lodash._root@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._root/-/lodash._root-3.0.1.tgz#fba1c4524c19ee9a5f8136b4609f017cf4ded692"
 
+lodash.chunk@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.chunk/-/lodash.chunk-4.2.0.tgz#66e5ce1f76ed27b4303d8c6512e8d1216e8106bc"
+
 lodash.create@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/lodash.create/-/lodash.create-3.1.1.tgz#d7f2849f0dbda7e04682bb8cd72ab022461debe7"
@@ -1999,6 +2164,19 @@ lodash@^4.14.0, lodash@^4.2.0:
   version "4.17.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.2.tgz#34a3055babe04ce42467b607d700072c7ff6bf42"
 
+log-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
+  dependencies:
+    chalk "^1.0.0"
+
+log-update@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-1.0.2.tgz#19929f64c4093d2d2e7075a1dad8af59c296b8d1"
+  dependencies:
+    ansi-escapes "^1.0.0"
+    cli-cursor "^1.0.2"
+
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -2026,6 +2204,13 @@ lru-cache@^4.0.0:
   dependencies:
     pseudomap "^1.0.1"
     yallist "^2.0.0"
+
+lru-cache@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
 
 makeerror@1.0.x:
   version "1.0.11"
@@ -2185,15 +2370,39 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
+normalize-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
+
 normalize-path@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.0.1.tgz#47886ac1662760d4261b7d979d241709d3ce3f7a"
+
+npm-path@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/npm-path/-/npm-path-2.0.3.tgz#15cff4e1c89a38da77f56f6055b24f975dfb2bbe"
+  dependencies:
+    which "^1.2.10"
 
 npm-run-path@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-1.0.0.tgz#f5c32bf595fe81ae927daec52e82f8b000ac3c8f"
   dependencies:
     path-key "^1.0.0"
+
+npm-run-path@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
+  dependencies:
+    path-key "^2.0.0"
+
+npm-which@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/npm-which/-/npm-which-3.0.1.tgz#9225f26ec3a285c209cae67c3b11a6b4ab7140aa"
+  dependencies:
+    commander "^2.9.0"
+    npm-path "^2.0.2"
+    which "^1.2.10"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -2234,6 +2443,10 @@ once@~1.3.0:
   dependencies:
     wrappy "1"
 
+onetime@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
+
 optimist@^0.6.1, optimist@~0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
@@ -2252,6 +2465,15 @@ optionator@^0.8.1:
     type-check "~0.3.2"
     wordwrap "~1.0.0"
 
+ora@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-0.2.3.tgz#37527d220adcd53c39b73571d754156d5db657a4"
+  dependencies:
+    chalk "^1.1.1"
+    cli-cursor "^1.0.2"
+    cli-spinners "^0.1.2"
+    object-assign "^4.0.1"
+
 ordered-read-streams@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz#7137e69b3298bb342247a1bbee3881c80e2fd78b"
@@ -2259,7 +2481,7 @@ ordered-read-streams@^0.3.0:
     is-stream "^1.0.1"
     readable-stream "^2.0.1"
 
-os-homedir@^1.0.0:
+os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
@@ -2272,6 +2494,10 @@ os-locale@^1.4.0:
 os-tmpdir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
+
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
 
 p-limit@^1.1.0:
   version "1.1.0"
@@ -2337,6 +2563,10 @@ path-key@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-1.0.0.tgz#5d53d578019646c0d68800db4e146e6bdc2ac7af"
 
+path-key@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
+
 path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
@@ -2385,6 +2615,10 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+prettier@^1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.5.3.tgz#59dadc683345ec6b88f88b94ed4ae7e1da394bfe"
+
 pretty-format@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-20.0.3.tgz#020e350a560a1fe1a98dc3beb6ccffb386de8b14"
@@ -2404,7 +2638,7 @@ prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
 
-pseudomap@^1.0.1:
+pseudomap@^1.0.1, pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
@@ -2568,6 +2802,10 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
 
+require-from-string@^1.1.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-1.2.1.tgz#529c9ccef27380adfec9a2f965b649bbee636418"
+
 require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
@@ -2586,6 +2824,13 @@ resolve@^1.3.2:
   dependencies:
     path-parse "^1.0.5"
 
+restore-cursor@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
+  dependencies:
+    exit-hook "^1.0.0"
+    onetime "^1.0.0"
+
 right-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
@@ -2603,6 +2848,12 @@ rimraf@^2.5.4:
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.5.4.tgz#96800093cbf1a0c86bd95b4625467535c29dfa04"
   dependencies:
     glob "^7.0.5"
+
+rxjs@^5.0.0-beta.11:
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.4.2.tgz#2a3236fcbf03df57bae06fd6972fd99e5c08fcf7"
+  dependencies:
+    symbol-observable "^1.0.1"
 
 safe-buffer@^5.0.1:
   version "5.0.1"
@@ -2638,6 +2889,16 @@ set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
 
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  dependencies:
+    shebang-regex "^1.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+
 shellwords@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.0.tgz#66afd47b6a12932d9071cbfd98a52e785cd0ba14"
@@ -2649,6 +2910,10 @@ signal-exit@^3.0.0:
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
+
+slice-ansi@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
 
 slide@^1.1.5:
   version "1.1.6"
@@ -2725,6 +2990,10 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
+staged-git-files@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-0.0.4.tgz#d797e1b551ca7a639dec0237dc6eb4bb9be17d35"
+
 stat-mode@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/stat-mode/-/stat-mode-0.2.2.tgz#e6c80b623123d7d80cf132ce538f346289072502"
@@ -2738,6 +3007,10 @@ stream-combiner@~0.0.4:
 stream-shift@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
+
+stream-to-observable@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/stream-to-observable/-/stream-to-observable-0.1.0.tgz#45bf1d9f2d7dc09bed81f1c307c430e68b84cffe"
 
 streamfilter@^1.0.5:
   version "1.0.5"
@@ -2811,6 +3084,10 @@ strip-indent@^1.0.1:
   dependencies:
     get-stdin "^4.0.1"
 
+strip-indent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
+
 strip-json-comments@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-1.0.4.tgz#1e15fbcac97d3ee99bf2d73b4c656b082bbafb91"
@@ -2824,6 +3101,10 @@ supports-color@3.1.2, supports-color@^3.1.2:
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+
+symbol-observable@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
 symbol-tree@^3.2.1:
   version "3.2.2"
@@ -2917,6 +3198,10 @@ tr46@~0.0.3:
 trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
+
+tslint-config-prettier@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.3.0.tgz#248997b8cdac1cd4953e05eb49129c0c6286cd89"
 
 tslint@^4.5.1:
   version "4.5.1"
@@ -3145,6 +3430,12 @@ which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
 
+which@^1.2.10, which@^1.2.9:
+  version "1.2.14"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
+  dependencies:
+    isexe "^2.0.0"
+
 which@^1.2.12, which@^1.2.8:
   version "1.2.12"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.12.tgz#de67b5e450269f194909ef23ece4ebe416fa1192"
@@ -3215,7 +3506,7 @@ y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
 
-yallist@^2.0.0:
+yallist@^2.0.0, yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 


### PR DESCRIPTION
https://github.com/prettier/prettier

I was poking around this morning, and when I save files in my IDE, prettier formats and writes that file. If you're open to it, I've run prettier using the configuration found in danger-js. This PR also sets up running prettier on staged files using lint-staged.

Lemme know what you think. If you're like the prettier configuration changed to include semicolons or anything else, happy to make those changes. 👍 