### PR TITLE
chore(settings): allow settings autocompletion

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,22 +42,21 @@
       }
     ],
     "configuration": {
+      "type": "object",
+      "title": "Jest configuration",
       "properties": {
         "jest.autoEnable": {
           "description": "Automatically starting Jest for this project.",
-          "title": "Automatically starting Jest for this project",
           "type": "boolean",
           "default": true
         },
         "jest.pathToJest": {
           "description": "The path to the Jest binary, or an npm command to run tests prefixed with `--` e.g. `npm test --`",
-          "title": "The path to the Jest binary, or an npm command to run tests prefixed with `--` e.g. `npm test --`",
           "type": "string",
           "default": "node_modules/.bin/jest"
         },
         "jest.pathToConfig": {
           "description": "The path to your Jest configuration file",
-          "title": "The path to your Jest configuration file",
           "type": "string",
           "default": ""
         },
@@ -71,8 +70,7 @@
           "type": "boolean",
           "default": true
         }
-      },
-      "title": "The settings for the Jest VS Code runner."
+      }
     },
     "commands": [
       {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/123822/31045866-42056bbc-a5ed-11e7-9c47-235f49d6eac4.png)

I don't really know why but I got "unknown" setting when typing "jest.pathToJest" in vscode. While with other extensions like flow it works perfectly.

It seems you are missing a `"type": "Object"` prop and also have some extra properties like titles for every option. Compared to flow that's the only difference.

vscode doc also says we may want to add type information (https://code.visualstudio.com/docs/extensionAPI/extension-points#_contributesconfiguration).