### PR TITLE
[enhancement] restart jest upon unexpected exit

### DIFF
--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -87,7 +87,7 @@ export class JestExt {
 
         if (maxRestart-- <= 0) {
           console.warn('jest has been restarted too many times, please check your system')
-          status.stopped('too many restart... abort')
+          status.stopped('(too many restart)')
           return
         }
 
@@ -163,6 +163,9 @@ export class JestExt {
     status.stopped()
   }
   private closeJest() {
+    if (!this.jestProcess) {
+      return
+    }
     this.forcedClose = true
     this.jestProcess.closeProcess()
   }

--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -21,7 +21,7 @@ import { TestReconciliationState } from './TestReconciliationState'
 import { pathToJestPackageJSON } from './helpers'
 import { readFileSync } from 'fs'
 import { Coverage, showCoverageOverlay } from './Coverage'
-import { updateDiagnostics, resetDiagnositics, failedSuiteCount } from './diagnostics'
+import { updateDiagnostics, resetDiagnostics, failedSuiteCount } from './diagnostics'
 
 export class JestExt {
   private workspace: ProjectWorkspace
@@ -48,7 +48,7 @@ export class JestExt {
   private failingAssertionDecorators: vscode.TextEditorDecorationType[]
 
   private clearOnNextInput: boolean
-  private forcedClose: boolean
+  private forcedClose = false
 
   constructor(workspace: ProjectWorkspace, outputChannel: vscode.OutputChannel, pluginSettings: IPluginSettings) {
     this.workspace = workspace
@@ -73,16 +73,32 @@ export class JestExt {
       delete this.jestProcess
     }
 
+    let maxRestart = 4
     this.jestProcess = new Runner(this.workspace)
 
     this.jestProcess
       .on('debuggerProcessExit', () => {
         this.channel.appendLine('Closed Jest')
-        if (!this.jestProcess.watchMode && !this.forcedClose) {
-          this.channel.appendLine('Starting watch mode...')
-          this.jestProcess.closeProcess()
-          this.jestProcess.start(true)
+
+        if (this.forcedClose) {
+          this.forcedClose = false
+          return
         }
+
+        if (maxRestart-- <= 0) {
+          console.warn('jest has been restarted too many times, please check your system')
+          status.stopped('too many restart... abort')
+          return
+        }
+
+        const msg = this.jestProcess.watchMode
+          ? 'jest exited unexpectedly, restarting watch mode'
+          : 'starting watch mode'
+        this.channel.appendLine(msg)
+        this.closeJest()
+
+        this.jestProcess.start(true)
+        status.running(msg)
       })
       .on('executableJSON', (data: JestTotalResults) => {
         this.updateWithData(data)
@@ -133,7 +149,7 @@ export class JestExt {
     // The bottom bar thing
     this.setupStatusBar()
     //reset the jest diagnostics
-    resetDiagnositics(this.failDiagnostics)
+    resetDiagnostics(this.failDiagnostics)
 
     this.forcedClose = false
     // Go!
@@ -142,10 +158,13 @@ export class JestExt {
 
   public stopProcess() {
     this.channel.appendLine('Closing Jest jest_runner.')
-    this.forcedClose = true
-    this.jestProcess.closeProcess()
+    this.closeJest()
     delete this.jestProcess
     status.stopped()
+  }
+  private closeJest() {
+    this.forcedClose = true
+    this.jestProcess.closeProcess()
   }
 
   private getSettings() {

--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -87,7 +87,7 @@ export class JestExt {
 
         if (maxRestart-- <= 0) {
           console.warn('jest has been restarted too many times, please check your system')
-          status.stopped('(too many restart)')
+          status.stopped('(too many restarts)')
           return
         }
 

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -23,13 +23,13 @@ export function updateDiagnostics(testResults: TestFileAssertionStatus[], diagno
       uri,
       asserts.map(assertion => {
         const start = 0
-        const daig = new vscode.Diagnostic(
+        const diag = new vscode.Diagnostic(
           new vscode.Range(assertion.line - 1, start, assertion.line - 1, start + 6),
           assertion.terseMessage || assertion.shortMessage || assertion.message,
           vscode.DiagnosticSeverity.Error
         )
-        daig.source = 'Jest'
-        return daig
+        diag.source = 'Jest'
+        return diag
       })
     )
   }
@@ -52,7 +52,7 @@ export function updateDiagnostics(testResults: TestFileAssertionStatus[], diagno
   })
 }
 
-export function resetDiagnositics(diagnostics: vscode.DiagnosticCollection) {
+export function resetDiagnostics(diagnostics: vscode.DiagnosticCollection) {
   diagnostics.clear()
 }
 export function failedSuiteCount(diagnostics: vscode.DiagnosticCollection): number {

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -37,7 +37,6 @@ export function failed(details?: string) {
 
 export function stopped(details?: string) {
   updateStatus('stopped', details)
-  setTimeout(() => initial(), 2000)
 }
 
 function updateStatus(message: string, details?: string) {

--- a/tests/JestExt.test.ts
+++ b/tests/JestExt.test.ts
@@ -99,7 +99,7 @@ describe('JestExt', () => {
       it('should not restart jest if closeProcess() is invoked by exit handler', () => {
         expect(eventEmitter.start).toHaveBeenCalledTimes(0)
         ;[true, false].forEach(watchMode => {
-          jest.resetAllMocks()
+          jest.clearAllMocks()
           eventEmitter.watchMode = watchMode
           handler()
           handler()
@@ -120,8 +120,6 @@ describe('JestExt', () => {
       }
       let handler: () => void
       beforeEach(() => {
-        // prepareMock()
-        // extension.startProcess()
         handler = getExitHandler()
         jest.clearAllMocks()
       })

--- a/tests/JestExt.test.ts
+++ b/tests/JestExt.test.ts
@@ -40,9 +40,11 @@ describe('JestExt', () => {
   describe('after starting the process', () => {
     const closeProcess = jest.fn()
     let extension: JestExt
+    let eventEmitter: any
 
     beforeEach(() => {
-      const eventEmitter = {
+      jest.resetAllMocks()
+      eventEmitter = {
         on: jest.fn(() => eventEmitter),
         start: jest.fn(),
         closeProcess,
@@ -53,14 +55,74 @@ describe('JestExt', () => {
     })
 
     it('should not attempt to closeProcess again after stopping and starting', () => {
+      expect(closeProcess).toHaveBeenCalledTimes(0)
       extension.stopProcess()
+      expect(closeProcess).toHaveBeenCalledTimes(1)
       extension.startProcess()
       expect(closeProcess).toHaveBeenCalledTimes(1)
     })
 
     it('should closeProcess when starting again', () => {
+      expect(closeProcess).toHaveBeenCalledTimes(0)
       extension.startProcess()
       expect(closeProcess).toHaveBeenCalledTimes(1)
+    })
+    describe('when jest process exit', () => {
+      function getExitHandler() {
+        return eventEmitter.on.mock.calls.filter(args => args[0] === 'debuggerProcessExit')[0][1]
+      }
+      function getJestWatchMode(index: number): boolean {
+        return eventEmitter.start.mock.calls[index][0]
+      }
+      let handler: () => void
+      beforeEach(() => {
+        handler = getExitHandler()
+        jest.resetAllMocks()
+      })
+      it('if non-watch mode, exit should reset process and trigger the watch mode', () => {
+        eventEmitter.watchMode = false
+        handler()
+
+        expect(eventEmitter.closeProcess).toHaveBeenCalledTimes(1)
+
+        expect(eventEmitter.start).toHaveBeenCalledTimes(1)
+        expect(getJestWatchMode(0)).toEqual(true)
+      })
+      it('in watch mode, exit should re-start the watch mode', () => {
+        eventEmitter.watchMode = true
+        handler()
+        expect(eventEmitter.closeProcess).toHaveBeenCalledTimes(1)
+        expect(eventEmitter.start).toHaveBeenCalledTimes(1)
+        expect(getJestWatchMode(0)).toEqual(true)
+      })
+      it('should not restart jest if closeProcess() is invoked by exit handler', () => {
+        expect(eventEmitter.start).toHaveBeenCalledTimes(0)
+        ;[true, false].forEach(watchMode => {
+          jest.resetAllMocks()
+          eventEmitter.watchMode = watchMode
+          handler()
+          handler()
+          expect(eventEmitter.start).toHaveBeenCalledTimes(1)
+          expect(getJestWatchMode(0)).toEqual(true)
+        })
+      })
+      it('should not restart jest if closeProcess() is invoked by user', () => {
+        extension.stopProcess()
+        expect(eventEmitter.closeProcess).toHaveBeenCalledTimes(1)
+        handler()
+        expect(eventEmitter.start).toHaveBeenCalledTimes(0)
+      })
+
+      it('will not restart if exceed maxRestart (4)', () => {
+        jest.resetAllMocks()
+        for (let i = 0; i < 7; i++) {
+          const j = Math.min(3, i)
+          handler()
+          expect(eventEmitter.closeProcess).toHaveBeenCalledTimes(j + 1)
+          expect(eventEmitter.start).toHaveBeenCalledTimes(j + 1)
+          handler()
+        }
+      })
     })
   })
 })

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -1,6 +1,6 @@
 jest.unmock('../src/diagnostics')
 
-import { updateDiagnostics, resetDiagnositics, failedSuiteCount } from '../src/diagnostics'
+import { updateDiagnostics, resetDiagnostics, failedSuiteCount } from '../src/diagnostics'
 import * as vscode from 'vscode'
 import { TestFileAssertionStatus, TestReconcilationState, TestAssertionStatus } from 'jest-editor-support'
 
@@ -16,10 +16,10 @@ class MockDiagnosticCollection implements vscode.DiagnosticCollection {
 }
 
 describe('test diagnostics', () => {
-  describe('resetDiagnositics', () => {
-    it('will clear given diagnositics', () => {
+  describe('resetDiagnostics', () => {
+    it('will clear given diagnostics', () => {
       const mockDiagnostics = new MockDiagnosticCollection()
-      resetDiagnositics(mockDiagnostics)
+      resetDiagnostics(mockDiagnostics)
       expect(mockDiagnostics.clear).toBeCalled()
     })
   })


### PR DESCRIPTION
per #150, #49

* restart jest process (in watch mode) upon unexpected process exit.
* set a max restart count to to prevent infinite-restart sequence, such as when the jest process couldn't start normally.
* keep the "stop" message and details visible (currently always override by "...").
* added more tests.
* fix some typo