### PR TITLE
Add support for using sub-folder as jest root path

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,11 @@
           "type": "string",
           "default": ""
         },
+        "jest.rootPath": {
+          "description": "The path to your frontend src folder",
+          "type": "string",
+          "default": ""
+        },
         "jest.enableInlineErrorMessages": {
           "description": "Whether errors should be reported inline on a file",
           "type": "boolean",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
 import { ProjectWorkspace } from 'jest-editor-support'
+import * as path from 'path';
 
 import { extensionName } from './appGlobals'
 import { pathToJest, pathToConfig } from './helpers'
@@ -20,7 +21,7 @@ export function activate(context: vscode.ExtensionContext) {
     pathToJest: workspaceConfig.get<string>('pathToJest'),
     enableInlineErrorMessages: workspaceConfig.get<boolean>('enableInlineErrorMessages'),
     enableSnapshotUpdateMessages: workspaceConfig.get<boolean>('enableSnapshotUpdateMessages'),
-    rootPath: vscode.workspace.rootPath,
+    rootPath: path.join(vscode.workspace.rootPath, workspaceConfig.get<string>('rootPath')),
   }
   const jestPath = pathToJest(pluginSettings)
   const configPath = pathToConfig(pluginSettings)


### PR DESCRIPTION
One scenario is: The project is a maven java project. Frontend code and
package.json/.jestrc files are in sub folder. Need to add a new config
'rootPath' to support run jest command in the subfolder