### PR TITLE
Add detection for the react-scripts executable

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -13,17 +13,9 @@ export function pathToJest(pluginSettings: IPluginSettings) {
   const path = normalize(pluginSettings.pathToJest)
 
   const defaultPath = normalize('node_modules/.bin/jest')
-  if (path === defaultPath) {
-    const defaultCreateReactPath = 'node_modules/react-scripts/node_modules/.bin/jest'
-    const defaultCreateReactPathWindows = 'node_modules/react-scripts/node_modules/.bin/jest.cmd'
-    const createReactPath = platform() === 'win32' ? defaultCreateReactPathWindows : defaultCreateReactPath
-    const absolutePath = join(pluginSettings.rootPath, createReactPath)
-
-    const craExists = existsSync(absolutePath)
-    if (craExists) {
-      // If it's the default, run the script instead
-      return platform() === 'win32' ? 'npm.cmd test --' : 'npm test --'
-    }
+  if (path === defaultPath && isBootstrappedWithCreateReactApp(pluginSettings.rootPath)) {
+    // If it's the default, run the script instead
+    return platform() === 'win32' ? 'npm.cmd test --' : 'npm test --'
   }
 
   // For windows support, see https://github.com/orta/vscode-jest/issues/10
@@ -31,6 +23,19 @@ export function pathToJest(pluginSettings: IPluginSettings) {
     return path + '.cmd'
   }
   return path
+}
+
+function isBootstrappedWithCreateReactApp(rootPath: string): boolean {
+  return (
+    hasExecutable(rootPath, 'node_modules/.bin/react-scripts') ||
+    hasExecutable(rootPath, 'node_modules/react-scripts/node_modules/.bin/jest')
+  )
+}
+
+function hasExecutable(rootPath: string, executablePath: string): boolean {
+  const ext = platform() === 'win32' ? '.cmd' : ''
+  const absolutePath = join(rootPath, executablePath + ext)
+  return existsSync(absolutePath)
 }
 
 /**


### PR DESCRIPTION
When a project is bootstrapped with `create-react-app` using the latest versions of node/npm, the `react-scripts` executable is installed in the top level `node_modules/.bin` directory. I've add this as the first path to check.

This fixes #161, closes #39, closes #113 and resolves facebookincubator/create-react-app#2709, and closes #125.