### PR TITLE
Add an option to control if all tests run before starting watch mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
       "title": "Jest configuration",
       "properties": {
         "jest.autoEnable": {
-          "description": "Automatically starting Jest for this project.",
+          "description": "Automatically start Jest for this project",
           "type": "boolean",
           "default": true
         },
@@ -74,6 +74,11 @@
         },
         "jest.enableSnapshotUpdateMessages": {
           "description": "Whether snapshot update messages should show",
+          "type": "boolean",
+          "default": true
+        },
+        "jest.runAllTestsFirst": {
+          "description": "Run all tests before starting Jest in watch mode",
           "type": "boolean",
           "default": true
         }

--- a/src/IPluginSettings.ts
+++ b/src/IPluginSettings.ts
@@ -5,4 +5,5 @@ export interface IPluginSettings {
   pathToJest?: string
   pathToConfig?: string
   rootPath?: string
+  runAllTestsFirst?: boolean
 }

--- a/src/JestExt.ts
+++ b/src/JestExt.ts
@@ -91,14 +91,8 @@ export class JestExt {
           return
         }
 
-        const msg = this.jestProcess.watchMode
-          ? 'jest exited unexpectedly, restarting watch mode'
-          : 'starting watch mode'
-        this.channel.appendLine(msg)
         this.closeJest()
-
-        this.jestProcess.start(true)
-        status.running(msg)
+        this.startWatchMode()
       })
       .on('executableJSON', (data: JestTotalResults) => {
         this.updateWithData(data)
@@ -153,7 +147,11 @@ export class JestExt {
 
     this.forcedClose = false
     // Go!
-    this.jestProcess.start(false)
+    if (this.pluginSettings.runAllTestsFirst) {
+      this.jestProcess.start(false)
+    } else {
+      this.startWatchMode()
+    }
   }
 
   public stopProcess() {
@@ -162,12 +160,20 @@ export class JestExt {
     delete this.jestProcess
     status.stopped()
   }
+
   private closeJest() {
     if (!this.jestProcess) {
       return
     }
     this.forcedClose = true
     this.jestProcess.closeProcess()
+  }
+
+  private startWatchMode() {
+    const msg = this.jestProcess.watchMode ? 'Jest exited unexpectedly, restarting watch mode' : 'Starting watch mode'
+    this.channel.appendLine(msg)
+    this.jestProcess.start(true)
+    status.running(msg)
   }
 
   private getSettings() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 import { ProjectWorkspace } from 'jest-editor-support'
-import * as path from 'path';
+import * as path from 'path'
 
 import { extensionName } from './appGlobals'
 import { pathToJest, pathToConfig } from './helpers'
@@ -22,6 +22,7 @@ export function activate(context: vscode.ExtensionContext) {
     enableInlineErrorMessages: workspaceConfig.get<boolean>('enableInlineErrorMessages'),
     enableSnapshotUpdateMessages: workspaceConfig.get<boolean>('enableSnapshotUpdateMessages'),
     rootPath: path.join(vscode.workspace.rootPath, workspaceConfig.get<string>('rootPath')),
+    runAllTestsFirst: workspaceConfig.get<boolean>('runAllTestsFirst'),
   }
   const jestPath = pathToJest(pluginSettings)
   const configPath = pathToConfig(pluginSettings)


### PR DESCRIPTION
A new setting called `runAllTestsFirst` has been added to control if Jest
will run all tests before starting watch mode. The default value is `true`
to preserve the existing behavior. This closes #151.