### PR TITLE
addressing illegal argument error when passing invalid line number

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -22,9 +22,18 @@ export function updateDiagnostics(testResults: TestFileAssertionStatus[], diagno
     diagnostics.set(
       uri,
       asserts.map(assertion => {
+        let line: number
+        if (assertion.line >= 0) {
+          line = Math.max(assertion.line - 1, 0)
+        } else {
+          line = 0
+          console.warn(
+            `received invalid line number '${assertion.line}' for '${uri.toString()}'. (most likely due to unexpected test results... you can help fix the root cause by logging an issue with a sample project to reproduce this warning)`
+          )
+        }
         const start = 0
         const diag = new vscode.Diagnostic(
-          new vscode.Range(assertion.line - 1, start, assertion.line - 1, start + 6),
+          new vscode.Range(line, start, line, start + 6),
           assertion.terseMessage || assertion.shortMessage || assertion.message,
           vscode.DiagnosticSeverity.Error
         )

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -23,7 +23,6 @@ describe('test diagnostics', () => {
       expect(mockDiagnostics.clear).toBeCalled()
     })
   })
-
   describe('updateDiagnostics', () => {
     // const MockReconciler = (TestReconciler as any) as jest.Mock<any>
 
@@ -143,6 +142,21 @@ describe('test diagnostics', () => {
       })
 
       expect(failedSuiteCount(mockDiagnostics)).toEqual(invokeCount)
+    })
+    it('should not produce negative diagnostic range', () => {
+      const mockDiagnostics = new MockDiagnosticCollection()
+      const assertion = createAssertion('a', 'KnownFail')
+      const invalidLine = [0, -1, undefined, null, NaN]
+      invalidLine.forEach(line => {
+        jest.clearAllMocks()
+        assertion.line = line
+        const tests = [createTestResult('f', [assertion])]
+        updateDiagnostics(tests, mockDiagnostics)
+
+        const rangeCalls = (vscode.Range as jest.Mock<any>).mock.calls
+        expect(rangeCalls.length).toEqual(1)
+        validateRange(rangeCalls[0], 0, 0)
+      })
     })
   })
 })


### PR DESCRIPTION
this is to address the symptom in #159 and #156. 

Note:
1. this doesn't address the actual root cause (that jest error parsing yield unexpected result), but merely making a best effort attempt to show the error as received. Hopefully, it will provide more hint on what the actual underlying error is...
1. I didn't have an actual use case to test against, only unit tested...
