### PR TITLE
Detect apps bootstrapped using react-scripts-ts

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -29,7 +29,8 @@ function isBootstrappedWithCreateReactApp(rootPath: string): boolean {
   return (
     hasExecutable(rootPath, 'node_modules/.bin/react-scripts') ||
     hasExecutable(rootPath, 'node_modules/react-scripts/node_modules/.bin/jest') ||
-    hasExecutable(rootPath, 'node_modules/react-native-scripts')
+    hasExecutable(rootPath, 'node_modules/react-native-scripts') ||
+    hasExecutable(rootPath, 'node_modules/react-scripts-ts')
   )
 }
 


### PR DESCRIPTION
This closes #190 by adding support for [`create-react-app-typescript`](https://github.com/wmonk/create-react-app-typescript). It also adds the feature request from #98 but doesn't address @Fendrian's [problem with the `.cmd` handling`](https://github.com/orta/vscode-jest/issues/98#issuecomment-338662610).

I've confirmed this works on my Linux box.