### PR TITLE
update jest 30 error detecton - auto switch jest30

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can see the full [features](#features) and learn more details in the [How-To
 Happy testing!
 
 ## Releases 
-- **Current** ([v6.4.3](https://github.com/jest-community/vscode-jest/releases/tag/v6.4.3)): [release note](release-notes/release-note-v6.md#v643)
+- **Current** ([v6.4.4](https://github.com/jest-community/vscode-jest/releases/tag/v6.4.4)): [release note](release-notes/release-note-v6.md#v644)
 - **Previous** ([v6.4.0](https://github.com/jest-community/vscode-jest/releases/tag/v6.4.0)): [release note](release-notes/release-note-v6.md#v640)
 
  

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-jest",
   "displayName": "Jest",
   "description": "Use Facebook's Jest With Pleasure.",
-  "version": "6.4.3",
+  "version": "6.4.4",
   "publisher": "Orta",
   "engines": {
     "vscode": "^1.88.1"

--- a/release-notes/release-note-v6.md
+++ b/release-notes/release-note-v6.md
@@ -3,6 +3,8 @@
 Release Notes <!-- omit in toc --> 
 ---
 
+- [v6.4.4](#v644)
+  - [Fixes](#fixes)
 - [v6.4.3](#v643)
   - [Bug Fixes](#bug-fixes)
   - [Other Changes](#other-changes)
@@ -51,10 +53,22 @@ Release Notes <!-- omit in toc -->
     - [2. Support spawning jest with dashed arguments](#2-support-spawning-jest-with-dashed-arguments)
     - [3. Control extension activation within each folder](#3-control-extension-activation-within-each-folder)
     - [4. Auto clear output upon test run](#4-auto-clear-output-upon-test-run)
-  - [Fixes](#fixes)
+  - [Fixes](#fixes-1)
   - [CHANGELOG](#changelog-3)
 
 ---
+
+## v6.4.4
+
+This release is a minor bug fix to auto switch jest30 settings. 
+
+### Fixes
+- Fixed jest 30 error detection so the system can auto switch to jest30 settings when the error is detected. ([#1254](https://github.com/jest-community/vscode-jest/pull/1254) by @connectdotz).
+- fix syntax in README.md. ([#1243](https://github.com/jest-community/vscode-jest/pull/1243) by @qqii)
+  
+**CHANGELOG**
+
+* [v6.4.4](https://github.com/jest-community/vscode-jest/releases/tag/v6.4.4)
 
 ## v6.4.3
 

--- a/src/JestExt/process-listeners.ts
+++ b/src/JestExt/process-listeners.ts
@@ -14,7 +14,7 @@ const POSSIBLE_ENV_ERROR_REGEX =
   /^(((?!(jest|react-scripts)).)*)(command not found|no such file or directory)/im;
 
 const TEST_PATH_PATTERNS_V30_ERROR_REGEX =
-  /Option "testPathPattern" was replaced by "testPathPatterns"\./i;
+  /Option "testPathPattern" was replaced by "--testPathPatterns"\./i;
 const TEST_PATH_PATTERNS_NOT_V30_ERROR_REGEX =
   /Unrecognized option "testPathPatterns". Did you mean "testPathPattern"\?/i;
 export class AbstractProcessListener {

--- a/src/extension-manager.ts
+++ b/src/extension-manager.ts
@@ -524,6 +524,7 @@ export class ExtensionManager {
 
 const ReleaseNoteBase = 'https://github.com/jest-community/vscode-jest/blob/master/release-notes';
 const ReleaseNotes: Record<string, string> = {
+  '6.4.4': `${ReleaseNoteBase}/release-note-v6.md#v644`,
   '6.4.3': `${ReleaseNoteBase}/release-note-v6.md#v643`,
   '6.4.2': `${ReleaseNoteBase}/release-note-v6.md#v642-pre-release`,
   '6.4.1': `${ReleaseNoteBase}/release-note-v6.md#v641-pre-release`,

--- a/tests/JestExt/process-listeners.test.ts
+++ b/tests/JestExt/process-listeners.test.ts
@@ -580,11 +580,11 @@ describe('jest process listeners', () => {
     describe('jest 30 support', () => {
       describe('can restart process if detected jest 30 related error', () => {
         it.each`
-          case | output                                                                            | useJest30Before | useJest30After | willRestart
-          ${1} | ${'Error in JestTestPatterns'}                                                    | ${null}         | ${null}        | ${false}
-          ${2} | ${'Error in JestTestPatterns'}                                                    | ${true}         | ${true}        | ${false}
-          ${3} | ${'Process Failed\nOption "testPathPattern" was replaced by "testPathPatterns".'} | ${null}         | ${true}        | ${true}
-          ${4} | ${'Process Failed\nOption "testPathPattern" was replaced by "testPathPatterns".'} | ${false}        | ${true}        | ${true}
+          case | output                                                                              | useJest30Before | useJest30After | willRestart
+          ${1} | ${'Error in JestTestPatterns'}                                                      | ${null}         | ${null}        | ${false}
+          ${2} | ${'Error in JestTestPatterns'}                                                      | ${true}         | ${true}        | ${false}
+          ${3} | ${'Process Failed\nOption "testPathPattern" was replaced by "--testPathPatterns".'} | ${null}         | ${true}        | ${true}
+          ${4} | ${'Process Failed\nOption "testPathPattern" was replaced by "--testPathPatterns".'} | ${false}        | ${true}        | ${true}
         `('case $case', ({ output, useJest30Before, useJest30After, willRestart }) => {
           expect.hasAssertions();
           mockSession.context.settings.useJest30 = useJest30Before;


### PR DESCRIPTION
This PR fixes our broken auto-switch for Jest 30 introduced in #1153. While manually setting the `jest.useJest30` flag works as expected, the automatic detection feature broke after Jest 30's official release because our regex no longer matched the new error message. This update revises the regex, restoring the auto-switch's functionality and making the transition to Jest 30 seamless without needing to manually set the flag.

resolves #1250
resolves #1248

